### PR TITLE
proto: rebase to latest CSI spec; use gogoslick for protoc

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -487,7 +487,7 @@ message ControllerServiceCapability {
   }
   
   oneof type {
-    // PRC that the controller supports.
+    // RPC that the controller supports.
     RPC rpc = 1;
     
     // Volume capability the Controller Plugin supports. An SP SHOULD
@@ -626,7 +626,7 @@ message NodeServiceCapability {
   }
   
   oneof type {
-    // PRC that the controller supports.
+    // RPC that the controller supports.
     RPC rpc = 1;
     
     // Volume capability the Node Plugin supports. An SP SHOULD avoid

--- a/proto.go
+++ b/proto.go
@@ -2,4 +2,4 @@ package csilvm
 
 //go:generate go run gen.go
 //go:generate docker build -t csilvm-proto -f Dockerfile.protobuf3 .
-//go:generate docker run --volume $PWD:/work csilvm-proto protoc --go_out=. csi.proto
+//go:generate docker run --volume $PWD:/work csilvm-proto protoc --gogoslick_out=. csi.proto


### PR DESCRIPTION
- executed `go generate .` this afternoon to pick up typo fixes in the spec
- updated `proto.go`: the protos appeared to be generated with "gogoslick" but `proto.go` didn't name that code generator (which I'm assuming was an error)