### PR TITLE
lvs: implement Controller service stub and ControllerGetCapabilities RPC

### DIFF
--- a/cmd/lvs/lvs.go
+++ b/cmd/lvs/lvs.go
@@ -25,5 +25,6 @@ func main() {
 	grpcServer := grpc.NewServer(opts...)
 	s := lvs.NewServer()
 	csi.RegisterIdentityServer(grpcServer, s)
+	csi.RegisterControllerServer(grpcServer, s)
 	grpcServer.Serve(lis)
 }

--- a/lvs/client.go
+++ b/lvs/client.go
@@ -1,0 +1,18 @@
+package lvs
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	grpc "google.golang.org/grpc"
+)
+
+type Client struct {
+	csi.IdentityClient
+	csi.ControllerClient
+}
+
+func NewClient(conn *grpc.ClientConn) *Client {
+	return &Client{
+		csi.NewIdentityClient(conn),
+		csi.NewControllerClient(conn),
+	}
+}

--- a/lvs/server.go
+++ b/lvs/server.go
@@ -22,6 +22,8 @@ func NewServer() *Server {
 	return new(Server)
 }
 
+// IdentityService RPCs
+
 func (s *Server) GetSupportedVersions(
 	ctx context.Context,
 	request *csi.GetSupportedVersionsRequest) (*csi.GetSupportedVersionsResponse, error) {
@@ -44,7 +46,7 @@ func (s *Server) GetPluginInfo(
 			&csi.GetPluginInfoResponse_Error{
 				&csi.Error{
 					&csi.Error_GeneralError_{
-						&csi.Error_GeneralError{csi.Error_GeneralError_MISSING_REQUIRED_FIELD, false, ""},
+						&csi.Error_GeneralError{csi.Error_GeneralError_MISSING_REQUIRED_FIELD, false, "The version must be specified."},
 					},
 				},
 			},
@@ -65,8 +67,147 @@ func (s *Server) GetPluginInfo(
 		&csi.GetPluginInfoResponse_Error{
 			&csi.Error{
 				&csi.Error_GeneralError_{
-					&csi.Error_GeneralError{csi.Error_GeneralError_UNSUPPORTED_REQUEST_VERSION, true, ""},
+					&csi.Error_GeneralError{csi.Error_GeneralError_UNSUPPORTED_REQUEST_VERSION, true, "The requested version is not supported."},
 				},
+			},
+		},
+	}
+	return response, nil
+}
+
+// ControllerService RPCs
+
+func (s *Server) CreateVolume(
+	ctx context.Context,
+	request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	panic("not implemented")
+}
+
+func (s *Server) DeleteVolume(
+	ctx context.Context,
+	request *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	panic("not implemented")
+}
+
+func (s *Server) ControllerPublishVolume(
+	ctx context.Context,
+	request *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	response := &csi.ControllerPublishVolumeResponse{
+		&csi.ControllerPublishVolumeResponse_Error{
+			&csi.Error{
+				&csi.Error_ControllerPublishVolumeError_{
+					&csi.Error_ControllerPublishVolumeError{csi.Error_ControllerPublishVolumeError_CALL_NOT_IMPLEMENTED, "The ControllerPublishVolume RPC is not supported.", nil},
+				},
+			},
+		},
+	}
+	return response, nil
+}
+
+func (s *Server) ControllerUnpublishVolume(
+	ctx context.Context,
+	request *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	response := &csi.ControllerUnpublishVolumeResponse{
+		&csi.ControllerUnpublishVolumeResponse_Error{
+			&csi.Error{
+				&csi.Error_ControllerUnpublishVolumeError_{
+					&csi.Error_ControllerUnpublishVolumeError{csi.Error_ControllerUnpublishVolumeError_CALL_NOT_IMPLEMENTED, "The ControllerUnpublishVolume RPC is not supported."},
+				},
+			},
+		},
+	}
+	return response, nil
+}
+
+func (s *Server) ValidateVolumeCapabilities(
+	ctx context.Context,
+	request *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	panic("not implemented")
+}
+
+func (s *Server) ListVolumes(
+	ctx context.Context,
+	request *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	panic("not implemented")
+}
+
+func (s *Server) GetCapacity(
+	ctx context.Context,
+	request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+	panic("not implemented")
+}
+
+func (s *Server) ControllerGetCapabilities(
+	ctx context.Context,
+	request *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+	version := request.GetVersion()
+	if version == nil {
+		response := &csi.ControllerGetCapabilitiesResponse{
+			&csi.ControllerGetCapabilitiesResponse_Error{
+				&csi.Error{
+					&csi.Error_GeneralError_{
+						&csi.Error_GeneralError{csi.Error_GeneralError_MISSING_REQUIRED_FIELD, false, "The version must be specified."},
+					},
+				},
+			},
+		}
+		return response, nil
+	}
+	supportedVersion := false
+	for _, v := range s.supportedVersions() {
+		if *v == *version {
+			supportedVersion = true
+			break
+		}
+	}
+	if !supportedVersion {
+		response := &csi.ControllerGetCapabilitiesResponse{
+			&csi.ControllerGetCapabilitiesResponse_Error{
+				&csi.Error{
+					&csi.Error_GeneralError_{
+						&csi.Error_GeneralError{csi.Error_GeneralError_UNSUPPORTED_REQUEST_VERSION, true, "The requested version is not supported."},
+					},
+				},
+			},
+		}
+		return response, nil
+	}
+	capabilities := []*csi.ControllerServiceCapability{
+		// CREATE_DELETE_VOLUME
+		{
+			&csi.ControllerServiceCapability_Rpc{
+				&csi.ControllerServiceCapability_RPC{
+					csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+				},
+			},
+		},
+		// PUBLISH_UNPUBLISH_VOLUME
+		//
+		//     Not supported by Controller service. This is
+		//     performed by the Node service for the Logical
+		//     Volume Service.
+		//
+		// LIST_VOLUMES
+		{
+			&csi.ControllerServiceCapability_Rpc{
+				&csi.ControllerServiceCapability_RPC{
+					csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
+				},
+			},
+		},
+		// GET_CAPACITY
+		{
+			&csi.ControllerServiceCapability_Rpc{
+				&csi.ControllerServiceCapability_RPC{
+					csi.ControllerServiceCapability_RPC_GET_CAPACITY,
+				},
+			},
+		},
+	}
+	response := &csi.ControllerGetCapabilitiesResponse{
+		&csi.ControllerGetCapabilitiesResponse_Result_{
+			&csi.ControllerGetCapabilitiesResponse_Result{
+				capabilities,
 			},
 		},
 	}


### PR DESCRIPTION
This PR implements a stubbed `Controller Service` for the LVS. The `ControllerGetCapabilities` RPC is fully implemented. The `ControllerPublishVolume` and `ControllerPublishVolume` are fully implemented in that they return the appropriate `CALL_NOT_IMPLEMENTED` responses.

Fixes https://jira.mesosphere.com/browse/DCOS-18800
Updates https://jira.mesosphere.com/browse/DCOS-18396