### PR TITLE
implement ValidateVolumeCapabilities RPC

### DIFF
--- a/lvs/errors.go
+++ b/lvs/errors.go
@@ -225,3 +225,51 @@ func ErrNodeUnpublishVolume_GeneralError_Undefined(err error) *csi.NodeUnpublish
 		},
 	}
 }
+
+// ValdiateVolumeCapabilities errors
+
+func ErrValidateVolumeCapabilities_VolumeDoesNotExist(err error) *csi.ValidateVolumeCapabilitiesResponse {
+	return &csi.ValidateVolumeCapabilitiesResponse{
+		&csi.ValidateVolumeCapabilitiesResponse_Error{
+			&csi.Error{
+				&csi.Error_ValidateVolumeCapabilitiesError_{
+					&csi.Error_ValidateVolumeCapabilitiesError{
+						csi.Error_ValidateVolumeCapabilitiesError_VOLUME_DOES_NOT_EXIST,
+						err.Error(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func ErrValidateVolumeCapabilities_UnsupportedFsType() *csi.ValidateVolumeCapabilitiesResponse {
+	return &csi.ValidateVolumeCapabilitiesResponse{
+		&csi.ValidateVolumeCapabilitiesResponse_Error{
+			&csi.Error{
+				&csi.Error_ValidateVolumeCapabilitiesError_{
+					&csi.Error_ValidateVolumeCapabilitiesError{
+						csi.Error_ValidateVolumeCapabilitiesError_UNSUPPORTED_FS_TYPE,
+						"Requested filesystem type is not supported.",
+					},
+				},
+			},
+		},
+	}
+}
+
+func ErrValidateVolumeCapabilities_GeneralError_Undefined(err error) *csi.ValidateVolumeCapabilitiesResponse {
+	return &csi.ValidateVolumeCapabilitiesResponse{
+		&csi.ValidateVolumeCapabilitiesResponse_Error{
+			&csi.Error{
+				&csi.Error_GeneralError_{
+					&csi.Error_GeneralError{
+						csi.Error_GeneralError_UNDEFINED,
+						callerMayRetry,
+						err.Error(),
+					},
+				},
+			},
+		},
+	}
+}

--- a/lvs/validate.go
+++ b/lvs/validate.go
@@ -346,6 +346,13 @@ func (s *Server) validateValidateVolumeCapabilitiesRequest(request *csi.Validate
 				}
 				return response, false
 			}
+			if mnt := volumeCapability.GetMount(); mnt != nil {
+				// This is a MOUNT_VOLUME request.
+				fstype := mnt.GetFsType()
+				if _, ok := s.supportedFilesystems[fstype]; !ok {
+					return ErrValidateVolumeCapabilities_UnsupportedFsType(), false
+				}
+			}
 			accessMode := volumeCapability.GetAccessMode()
 			if accessMode == nil {
 				response := &csi.ValidateVolumeCapabilitiesResponse{


### PR DESCRIPTION
This PR implements the `ValidateVolumeCapabilities` RPC. It ensures that the requested filesystems are supported. If the volume is already formatted with a given filesystem, it checks that any requested MountVolume capability's fs_type matches it.

Fixes https://jira.mesosphere.com/browse/DCOS-19089