### PR TITLE
Implement ListVolumes RPC

### DIFF
--- a/lvs/errors.go
+++ b/lvs/errors.go
@@ -306,3 +306,21 @@ func ErrProbeNode_GeneralError_Undefined(err error) *csi.ProbeNodeResponse {
 		},
 	}
 }
+
+// ListVolumes errors
+
+func ErrListVolumes_GeneralError_Undefined(err error) *csi.ListVolumesResponse {
+	return &csi.ListVolumesResponse{
+		&csi.ListVolumesResponse_Error{
+			&csi.Error{
+				&csi.Error_GeneralError_{
+					&csi.Error_GeneralError{
+						csi.Error_GeneralError_UNDEFINED,
+						callerMayRetry,
+						err.Error(),
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This PR implements the `ListVolumes` RPC for single nodes. The `ListVolumes` RPC is technically a Controller RPC which suggests that it should list *all* volumes across all hosts. This is a minimal implementation that lists only those volumes present on the a given agent.

Fixes https://jira.mesosphere.com/browse/DCOS-19092