### PR TITLE
lvs: implement GetCapacity RPC

### DIFF
--- a/lvs/errors.go
+++ b/lvs/errors.go
@@ -324,3 +324,21 @@ func ErrListVolumes_GeneralError_Undefined(err error) *csi.ListVolumesResponse {
 		},
 	}
 }
+
+// GetCapacity errors
+
+func ErrGetCapacity_GeneralError_Undefined(err error) *csi.GetCapacityResponse {
+	return &csi.GetCapacityResponse{
+		&csi.GetCapacityResponse_Error{
+			&csi.Error{
+				&csi.Error_GeneralError_{
+					&csi.Error_GeneralError{
+						csi.Error_GeneralError_UNDEFINED,
+						callerMayRetry,
+						err.Error(),
+					},
+				},
+			},
+		},
+	}
+}

--- a/lvs/server.go
+++ b/lvs/server.go
@@ -308,7 +308,17 @@ func (s *Server) GetCapacity(
 	if response, ok := s.validateGetCapacityRequest(request); !ok {
 		return response, nil
 	}
-	response := &csi.GetCapacityResponse{}
+	bytesFree, err := s.volumeGroup.BytesFree()
+	if err != nil {
+		return ErrGetCapacity_GeneralError_Undefined(err), nil
+	}
+	response := &csi.GetCapacityResponse{
+		&csi.GetCapacityResponse_Result_{
+			&csi.GetCapacityResponse_Result{
+				bytesFree,
+			},
+		},
+	}
 	return response, nil
 }
 

--- a/lvs/validate.go
+++ b/lvs/validate.go
@@ -473,6 +473,21 @@ func (s *Server) validateGetCapacityRequest(request *csi.GetCapacityRequest) (*c
 				}
 				return response, false
 			}
+			if mnt := volumeCapability.GetMount(); mnt != nil {
+				// This is a MOUNT_VOLUME request.
+				fstype := mnt.GetFsType()
+				if _, ok := s.supportedFilesystems[fstype]; !ok {
+					// Zero capacity for unsupported filesystem type.
+					response := &csi.GetCapacityResponse{
+						&csi.GetCapacityResponse_Result_{
+							&csi.GetCapacityResponse_Result{
+								0,
+							},
+						},
+					}
+					return response, false
+				}
+			}
 			accessMode := volumeCapability.GetAccessMode()
 			if accessMode == nil {
 				response := &csi.GetCapacityResponse{

--- a/lvs/validate_test.go
+++ b/lvs/validate_test.go
@@ -742,7 +742,7 @@ func TestListVolumesUnsupportedVersion(t *testing.T) {
 func TestGetCapacityMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
-	req := testGetCapacityRequest()
+	req := testGetCapacityRequest("xfs")
 	req.Version = nil
 	resp, err := client.GetCapacity(context.Background(), req)
 	if err != nil {
@@ -769,7 +769,7 @@ func TestGetCapacityMissingVersion(t *testing.T) {
 func TestGetCapacityUnsupportedVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
-	req := testGetCapacityRequest()
+	req := testGetCapacityRequest("xfs")
 	req.Version = &csi.Version{0, 2, 0}
 	resp, err := client.GetCapacity(context.Background(), req)
 	if err != nil {
@@ -796,7 +796,7 @@ func TestGetCapacityUnsupportedVersion(t *testing.T) {
 func TestGetCapacityMissingVolumeCapabilitiesAccessType(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
-	req := testGetCapacityRequest()
+	req := testGetCapacityRequest("xfs")
 	req.VolumeCapabilities[0].AccessType = nil
 	resp, err := client.GetCapacity(context.Background(), req)
 	if err != nil {
@@ -820,10 +820,27 @@ func TestGetCapacityMissingVolumeCapabilitiesAccessType(t *testing.T) {
 	}
 }
 
+func TestGetCapacity_BadFilesystem(t *testing.T) {
+	client, cleanup := startTest()
+	defer cleanup()
+	req := testGetCapacityRequest("ext4")
+	resp, err := client.GetCapacity(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := resp.GetError(); err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result.GetAvailableCapacity() != 0 {
+		t.Fatalf("Expected 0 bytes for unsupported filesystem but got %v.", result.GetAvailableCapacity())
+	}
+}
+
 func TestGetCapacityMissingVolumeCapabilitiesAccessMode(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
-	req := testGetCapacityRequest()
+	req := testGetCapacityRequest("xfs")
 	req.VolumeCapabilities[0].AccessMode = nil
 	resp, err := client.GetCapacity(context.Background(), req)
 	if err != nil {
@@ -850,7 +867,7 @@ func TestGetCapacityMissingVolumeCapabilitiesAccessMode(t *testing.T) {
 func TestGetCapacityVolumeCapabilitiesAccessModeUNKNOWN(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
-	req := testGetCapacityRequest()
+	req := testGetCapacityRequest("xfs")
 	req.VolumeCapabilities[0].AccessMode.Mode = csi.VolumeCapability_AccessMode_UNKNOWN
 	resp, err := client.GetCapacity(context.Background(), req)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for the GetCapacity RPC.

Fixes https://jira.mesosphere.com/browse/DCOS-19093