### PR TITLE
lvs: Add -remove-volume-group flag

### DIFF
--- a/cmd/lvs/lvs.go
+++ b/cmd/lvs/lvs.go
@@ -17,15 +17,13 @@ const (
 	defaultDefaultVolumeSize = 10 << 30
 )
 
-var (
-	vgnameF            = flag.String("volume-group", "", "The name of the volume group to manage")
-	pvnamesF           = flag.String("devices", "", "A comma-seperated list of devices in the volume group")
-	defaultFsF         = flag.String("default-fs", defaultDefaultFs, "The default filesystem to format new volumes with")
-	defaultVolumeSizeF = flag.Uint64("default-volume-size", defaultDefaultVolumeSize, "The default volume size in bytes")
-	socketFileF        = flag.String("unix-addr", "", "The path to the listening unix socket file")
-)
-
 func main() {
+	vgnameF := flag.String("volume-group", "", "The name of the volume group to manage")
+	pvnamesF := flag.String("devices", "", "A comma-seperated list of devices in the volume group")
+	defaultFsF := flag.String("default-fs", defaultDefaultFs, "The default filesystem to format new volumes with")
+	defaultVolumeSizeF := flag.Uint64("default-volume-size", defaultDefaultVolumeSize, "The default volume size in bytes")
+	socketFileF := flag.String("unix-addr", "", "The path to the listening unix socket file")
+	removeF := flag.Bool("remove-volume-group", false, "If set, the volume group will be removed when ProbeNode is called.")
 	flag.Parse()
 	lis, err := net.Listen("unix", *socketFileF)
 	if err != nil {
@@ -34,6 +32,9 @@ func main() {
 	grpcServer := grpc.NewServer()
 	var opts []lvs.ServerOpt
 	opts = append(opts, lvs.DefaultVolumeSize(*defaultVolumeSizeF))
+	if removeF {
+		opts = append(opts, lvs.RemoveVolumeGroup())
+	}
 	s := lvs.NewServer(*vgnameF, strings.Split(*pvnamesF, ","), *defaultFsF, opts...)
 	csi.RegisterIdentityServer(grpcServer, s)
 	csi.RegisterControllerServer(grpcServer, s)

--- a/lvs/validate.go
+++ b/lvs/validate.go
@@ -9,6 +9,21 @@ const (
 	callerMayRetry     = false
 )
 
+func (s *Server) validateRemoving() *csi.Error {
+	if s.removingVolumeGroup {
+		return &csi.Error{
+			&csi.Error_GeneralError_{
+				&csi.Error_GeneralError{
+					csi.Error_GeneralError_UNDEFINED,
+					callerMustNotRetry,
+					"This service is running in 'remove volume group' mode.",
+				},
+			},
+		}
+	}
+	return nil
+}
+
 func (s *Server) validateVersion(version *csi.Version) *csi.Error {
 	if version == nil {
 		return &csi.Error{
@@ -143,6 +158,14 @@ func (s *Server) validateGetPluginInfoRequest(request *csi.GetPluginInfoRequest)
 // ControllerService RPCs
 
 func (s *Server) validateCreateVolumeRequest(request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.CreateVolumeResponse{
+			&csi.CreateVolumeResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.CreateVolumeResponse{
 			&csi.CreateVolumeResponse_Error{
@@ -184,6 +207,14 @@ func (s *Server) validateCreateVolumeRequest(request *csi.CreateVolumeRequest) (
 }
 
 func (s *Server) validateDeleteVolumeRequest(request *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.DeleteVolumeResponse{
+			&csi.DeleteVolumeResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.DeleteVolumeResponse{
 			&csi.DeleteVolumeResponse_Error{
@@ -204,6 +235,14 @@ func (s *Server) validateDeleteVolumeRequest(request *csi.DeleteVolumeRequest) (
 }
 
 func (s *Server) validateValidateVolumeCapabilitiesRequest(request *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.ValidateVolumeCapabilitiesResponse{
+			&csi.ValidateVolumeCapabilitiesResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.ValidateVolumeCapabilitiesResponse{
 			&csi.ValidateVolumeCapabilitiesResponse_Error{
@@ -254,6 +293,14 @@ func (s *Server) validateValidateVolumeCapabilitiesRequest(request *csi.Validate
 }
 
 func (s *Server) validateListVolumesRequest(request *csi.ListVolumesRequest) (*csi.ListVolumesResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.ListVolumesResponse{
+			&csi.ListVolumesResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.ListVolumesResponse{
 			&csi.ListVolumesResponse_Error{
@@ -266,6 +313,14 @@ func (s *Server) validateListVolumesRequest(request *csi.ListVolumesRequest) (*c
 }
 
 func (s *Server) validateGetCapacityRequest(request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.GetCapacityResponse{
+			&csi.GetCapacityResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.GetCapacityResponse{
 			&csi.GetCapacityResponse_Error{
@@ -290,7 +345,6 @@ func (s *Server) validateGetCapacityRequest(request *csi.GetCapacityRequest) (*c
 					},
 				}
 				return response, false
-
 			}
 			// Check for unsupported filesystem type in
 			// order to return 0 capacity if it isn't
@@ -316,6 +370,14 @@ func (s *Server) validateGetCapacityRequest(request *csi.GetCapacityRequest) (*c
 }
 
 func (s *Server) validateControllerGetCapabilitiesRequest(request *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.ControllerGetCapabilitiesResponse{
+			&csi.ControllerGetCapabilitiesResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.ControllerGetCapabilitiesResponse{
 			&csi.ControllerGetCapabilitiesResponse_Error{
@@ -330,6 +392,14 @@ func (s *Server) validateControllerGetCapabilitiesRequest(request *csi.Controlle
 // NodeService RPCs
 
 func (s *Server) validateNodePublishVolumeRequest(request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.NodePublishVolumeResponse{
+			&csi.NodePublishVolumeResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.NodePublishVolumeResponse{
 			&csi.NodePublishVolumeResponse_Error{
@@ -405,6 +475,14 @@ func (s *Server) validateNodePublishVolumeRequest(request *csi.NodePublishVolume
 }
 
 func (s *Server) validateNodeUnpublishVolumeRequest(request *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.NodeUnpublishVolumeResponse{
+			&csi.NodeUnpublishVolumeResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.NodeUnpublishVolumeResponse{
 			&csi.NodeUnpublishVolumeResponse_Error{
@@ -438,6 +516,14 @@ func (s *Server) validateNodeUnpublishVolumeRequest(request *csi.NodeUnpublishVo
 }
 
 func (s *Server) validateGetNodeIDRequest(request *csi.GetNodeIDRequest) (*csi.GetNodeIDResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.GetNodeIDResponse{
+			&csi.GetNodeIDResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.GetNodeIDResponse{
 			&csi.GetNodeIDResponse_Error{
@@ -462,6 +548,14 @@ func (s *Server) validateProbeNodeRequest(request *csi.ProbeNodeRequest) (*csi.P
 }
 
 func (s *Server) validateNodeGetCapabilitiesRequest(request *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, bool) {
+	if err := s.validateRemoving(); err != nil {
+		response := &csi.NodeGetCapabilitiesResponse{
+			&csi.NodeGetCapabilitiesResponse_Error{
+				err,
+			},
+		}
+		return response, false
+	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.NodeGetCapabilitiesResponse{
 			&csi.NodeGetCapabilitiesResponse_Error{

--- a/lvs/validate_test.go
+++ b/lvs/validate_test.go
@@ -66,6 +66,33 @@ func TestGetPluginInfoUnsupportedVersion(t *testing.T) {
 
 // ControllerService RPCs
 
+func TestCreateVolumeRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testCreateVolumeRequest()
+	req.Version = nil
+	resp, err := client.CreateVolume(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
 func TestCreateVolumeMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
@@ -283,6 +310,33 @@ func TestCreateVolumeVolumeCapabilitiesAccessModeUNKNOWN(t *testing.T) {
 	}
 }
 
+func TestDeleteVolumeRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testDeleteVolumeRequest("test-volume")
+	req.Version = nil
+	resp, err := client.DeleteVolume(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
 func TestDeleteVolumeMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
@@ -386,6 +440,33 @@ func TestDeleteVolumeMissingVolumeHandleId(t *testing.T) {
 		t.Fatal("Expected CallerMustNotRetry to be false")
 	}
 	expdesc := "The volume_handle.id field must be specified."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
+func TestValidateVolumeCapabilitiesRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testValidateVolumeCapabilitiesRequest(fakeVolumeHandle(), "", nil)
+	req.Version = nil
+	resp, err := client.ValidateVolumeCapabilities(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
 	if error.GetErrorDescription() != expdesc {
 		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
 	}
@@ -685,6 +766,33 @@ func TestValidateVolumeCapabilitiesVolumeCapabilitiesAccessModeUNKNOWN(t *testin
 	}
 }
 
+func TestListVolumesRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testListVolumesRequest()
+	req.Version = nil
+	resp, err := client.ListVolumes(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
 func TestListVolumesMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
@@ -734,6 +842,33 @@ func TestListVolumesUnsupportedVersion(t *testing.T) {
 		t.Fatal("Expected CallerMustNotRetry to be true")
 	}
 	expdesc := "The requested version is not supported."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
+func TestGetCapacityRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testGetCapacityRequest("xfs")
+	req.Version = nil
+	resp, err := client.GetCapacity(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
 	if error.GetErrorDescription() != expdesc {
 		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
 	}
@@ -891,6 +1026,33 @@ func TestGetCapacityVolumeCapabilitiesAccessModeUNKNOWN(t *testing.T) {
 	}
 }
 
+func TestControllerGetCapabilitiesRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := &csi.ControllerGetCapabilitiesRequest{}
+	req.Version = nil
+	resp, err := client.ControllerGetCapabilities(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
 func TestControllerGetCapabilitiesInfoMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
@@ -950,6 +1112,33 @@ func fakeVolumeHandle() *csi.VolumeHandle {
 }
 
 var fakeMountDir = "/run/dcos/csilvm/mnt"
+
+func TestNodePublishVolumeRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testNodePublishVolumeRequest(fakeVolumeHandle(), fakeMountDir, "", nil)
+	req.Version = nil
+	resp, err := client.NodePublishVolume(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
 
 func TestNodePublishVolumeMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
@@ -1246,6 +1435,33 @@ func TestNodePublishVolumeNodeUnpublishVolume_MountVolume_BadFilesystem(t *testi
 
 var fakeTargetPath = filepath.Join(fakeMountDir, fakeVolumeHandle().GetId())
 
+func TestNodeUnpublishVolumeRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testNodeUnpublishVolumeRequest(fakeVolumeHandle(), fakeTargetPath)
+	req.Version = nil
+	resp, err := client.NodeUnpublishVolume(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
 func TestNodeUnpublishVolumeMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
@@ -1381,6 +1597,33 @@ func TestNodeUnpublishVolumeMissingTargetPath(t *testing.T) {
 	}
 }
 
+func TestGetNodeID_RemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testGetNodeIDRequest()
+	req.Version = nil
+	resp, err := client.GetNodeID(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
 func TestGetNodeIDMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()
@@ -1484,6 +1727,33 @@ func TestProbeNodeUnsupportedVersion(t *testing.T) {
 		t.Fatal("Expected CallerMustNotRetry to be true")
 	}
 	expdesc := "The requested version is not supported."
+	if error.GetErrorDescription() != expdesc {
+		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
+	}
+}
+
+func TestNodeGetCapabilitiesRemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testNodeGetCapabilitiesRequest()
+	req.Version = nil
+	resp, err := client.NodeGetCapabilities(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result != nil {
+		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
+	}
+	error := resp.GetError().GetGeneralError()
+	expcode := csi.Error_GeneralError_UNDEFINED
+	if error.GetErrorCode() != expcode {
+		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
+	}
+	if error.GetCallerMustNotRetry() != true {
+		t.Fatal("Expected CallerMustNotRetry to be true")
+	}
+	expdesc := "This service is running in 'remove volume group' mode."
 	if error.GetErrorDescription() != expdesc {
 		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
 	}


### PR DESCRIPTION
This PR adds support for removing a volume group by additionally specifying a `-remove-volume-group` flag on the command line. The actual removal is performed when `ProbeNode` is called. All calls other than `GetSupportedVersions` and `ProbeNode` will return an error when the LVS has been started with the `-remove-volume-group` flag.

Fixes https://jira.mesosphere.com/browse/DCOS-19150