### PR TITLE
lvs: GetCapacity returns 0 when removing volume group

### DIFF
--- a/lvs/lvs_test.go
+++ b/lvs/lvs_test.go
@@ -1004,6 +1004,21 @@ func TestGetCapacity_OneVolume(t *testing.T) {
 	}
 }
 
+func TestGetCapacity_RemoveVolumeGroup(t *testing.T) {
+	client, cleanup := startTest(RemoveVolumeGroup())
+	defer cleanup()
+	req := testGetCapacityRequest("xfs")
+	req.Version = nil
+	resp, err := client.GetCapacity(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.GetResult()
+	if result.GetAvailableCapacity() != 0 {
+		t.Fatalf("Expected 0 bytes free but got %v.", result.GetAvailableCapacity())
+	}
+}
+
 func TestControllerGetCapabilities(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()

--- a/lvs/server.go
+++ b/lvs/server.go
@@ -370,6 +370,17 @@ func (s *Server) GetCapacity(
 	if response, ok := s.validateGetCapacityRequest(request); !ok {
 		return response, nil
 	}
+	if s.removingVolumeGroup {
+		// We report 0 capacity if configured to remove the volume group.
+		response := &csi.GetCapacityResponse{
+			&csi.GetCapacityResponse_Result_{
+				&csi.GetCapacityResponse_Result{
+					0,
+				},
+			},
+		}
+		return response, nil
+	}
 	bytesFree, err := s.volumeGroup.BytesFree()
 	if err != nil {
 		return ErrGetCapacity_GeneralError_Undefined(err), nil

--- a/lvs/validate.go
+++ b/lvs/validate.go
@@ -313,14 +313,6 @@ func (s *Server) validateListVolumesRequest(request *csi.ListVolumesRequest) (*c
 }
 
 func (s *Server) validateGetCapacityRequest(request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, bool) {
-	if err := s.validateRemoving(); err != nil {
-		response := &csi.GetCapacityResponse{
-			&csi.GetCapacityResponse_Error{
-				err,
-			},
-		}
-		return response, false
-	}
 	if err := s.validateVersion(request.GetVersion()); err != nil {
 		response := &csi.GetCapacityResponse{
 			&csi.GetCapacityResponse_Error{

--- a/lvs/validate_test.go
+++ b/lvs/validate_test.go
@@ -847,33 +847,6 @@ func TestListVolumesUnsupportedVersion(t *testing.T) {
 	}
 }
 
-func TestGetCapacityRemoveVolumeGroup(t *testing.T) {
-	client, cleanup := startTest(RemoveVolumeGroup())
-	defer cleanup()
-	req := testGetCapacityRequest("xfs")
-	req.Version = nil
-	resp, err := client.GetCapacity(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	result := resp.GetResult()
-	if result != nil {
-		t.Fatalf("Expected Result to be nil but was: %+v", resp.GetResult())
-	}
-	error := resp.GetError().GetGeneralError()
-	expcode := csi.Error_GeneralError_UNDEFINED
-	if error.GetErrorCode() != expcode {
-		t.Fatalf("Expected error code %d but got %d", expcode, error.GetErrorCode())
-	}
-	if error.GetCallerMustNotRetry() != true {
-		t.Fatal("Expected CallerMustNotRetry to be true")
-	}
-	expdesc := "This service is running in 'remove volume group' mode."
-	if error.GetErrorDescription() != expdesc {
-		t.Fatalf("Expected ErrorDescription to be '%s' but was '%s'", expdesc, error.GetErrorDescription())
-	}
-}
-
 func TestGetCapacityMissingVersion(t *testing.T) {
 	client, cleanup := startTest()
 	defer cleanup()


### PR DESCRIPTION
```
a3. when the SLRP invokes the reconfiguration that happens to delete the VG, 
the plugin will report 0 capacity. there's no special action needed by the SLRP
here - it's a case that SLRP should already handle (when capacity is 
diminished, or gone). DSS will invoke an API to remove the configuration 
once it sees that the plugin reconfiguration (with the delete) has succeeded 
(because the plugin is healthy).
```
~ https://mesosphere.slack.com/archives/C04GJD43Q/p1508946853000917

Fixes https://jira.mesosphere.com/browse/DCOS-19306