### PR TITLE
log vgname as log prefix

### DIFF
--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	stdlog "log"
 	"net"
 	"os"
 	"os/exec"
@@ -36,7 +36,7 @@ var (
 
 func init() {
 	// Set test logging
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	stdlog.SetFlags(stdlog.LstdFlags | stdlog.Lshortfile)
 	// Refresh the LVM metadata held by the lvmetad process to
 	// clear any metadata left over from a previous run.
 	if err := lvm.PVScan(""); err != nil {
@@ -2856,6 +2856,10 @@ func prepareProbeNodeTest(vgname string, pvnames []string, serverOpts ...ServerO
 	})
 
 	var opts []grpc.ServerOption
+	// setup logging
+	logprefix := fmt.Sprintf("[%s]", vgname)
+	logflags := stdlog.LstdFlags | stdlog.Lshortfile
+	SetLogger(stdlog.New(os.Stderr, logprefix, logflags))
 	// Start a grpc server listening on the socket.
 	grpcServer := grpc.NewServer(opts...)
 	s := NewServer(vgname, pvnames, "xfs", serverOpts...)

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	stdlog "log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,6 +22,17 @@ import (
 
 const PluginName = "io.mesosphere.dcos.storage/csilvm"
 const PluginVersion = "1.11.0"
+
+type logger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
+var log logger = stdlog.New(os.Stderr, "", stdlog.LstdFlags|stdlog.Lshortfile)
+
+func SetLogger(l logger) {
+	log = l
+}
 
 type Server struct {
 	vgname               string

--- a/pkg/csilvm/validate.go
+++ b/pkg/csilvm/validate.go
@@ -1,8 +1,6 @@
 package csilvm
 
 import (
-	"log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 


### PR DESCRIPTION
This makes the volume group name be a log prefix to help disambiguate multiple plugin instances from one another in log files.

Updates https://jira.mesosphere.com/browse/DCOS-19445