### PR TITLE
pkg/csilvm: use strict java naming convention

### DIFF
--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const PluginName = "io.mesosphere.dcos.storage/csilvm"
+const PluginName = "io.mesosphere.dcos.storage.csilvm"
 const PluginVersion = "1.11.0"
 
 type Server struct {


### PR DESCRIPTION
This PR renames the plugin's name to use `.` instead of `/`.