### PR TITLE
use blkid instead of lsblk to avoid udev caching, switch to centos:7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y gcc gcc-c++ make git lvm2-devel blkid
+RUN yum install -y gcc-4.8.5 gcc-c++-4.8.5 make git lvm2-devel util-linux
 
 ENV GOLANG_VERSION 1.9.2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM golang:1.9.2
+FROM centos:7
 
-RUN apt-get update && \
-    apt-get install -y liblvm2-dev
+RUN yum install -y gcc gcc-c++ make git lvm2-devel blkid
+
+ENV GOLANG_VERSION 1.9.2
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b
+
+RUN rm -rf /usr/local/go && \
+      curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
+      echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
+      tar -C /usr/local -xzf golang.tar.gz && \
+      rm -f golang.tar.gz
+
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+ENV PATH /usr/local/go/bin:$PATH
 
 RUN mkdir -p /go/src/github.com/alecthomas && \
     cd /go/src/github.com/alecthomas && \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Logical volumes are named according to the following pattern
 The following command-line utilties must be present in the `PATH`:
 
 * `udevadm`
-* `lsblk`
+* `blkid`
 * `pvscan` from the lvm2 utils
 * `mkfs`
 * the filesystem listed as `-default-fs` (defaults to: `xfs`)


### PR DESCRIPTION
This PR switches from `lsblk`, which reads cached data from udev, to `blkid -c /dev/null` which reads filesystem information from the block device and is therefore up-to-date.

It also switches from the golang:1.9.2 container to centos:7 and installs golang in a separate step. This is due to our targeting primarily centos:7 and not debian.