### PR TITLE
Fix parsing of /proc/self/mountinfo for idempotent publishing and run tests in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y gcc-4.8.5 gcc-c++-4.8.5 make git lvm2-devel util-linux
+RUN yum install -y gcc-4.8.5 gcc-c++-4.8.5 make git lvm2-devel util-linux xfsprogs file
 
 ENV GOLANG_VERSION 1.9.2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
@@ -23,5 +23,9 @@ RUN mkdir -p /go/src/github.com/alecthomas && \
     gometalinter --install && \
     go get -u golang.org/x/tools/cmd/goimports && \
     mkdir -p /go/src/github.com/mesosphere/csilvm
+
+# We explicitly disable use of lvmetad as the cache appears to yield inconsistent results,
+# at least when running in docker.
+RUN sed -i 's/use_lvmetad = 1/use_lvmetad = 0/' /etc/lvm/lvm.conf
 
 WORKDIR /go/src/github.com/mesosphere/csilvm

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dev-image:
 	docker inspect $(DEV_DOCKER_IMAGE) &> /dev/null || docker build --rm -t $(DEV_DOCKER_IMAGE) .
 
 ifeq ($(DOCKER), yes)
-TEST_PREFIX := docker run --rm $(DEV_DOCKER_IMAGE)
+TEST_PREFIX := docker run --rm --privileged -v /run:/run -v /tmp:/tmp -v `pwd`:/go/src/github.com/mesosphere/csilvm -v /dev:/dev --ipc=host $(DEV_DOCKER_IMAGE)
 BUILD_PREFIX := docker run --rm -v `pwd`:/go/src/github.com/mesosphere/csilvm $(DEV_DOCKER_IMAGE)
 
 build: dev-image
@@ -53,7 +53,5 @@ all: build
 
 .PHONY: sudo-test
 sudo-test:
-	go test -c -i ./pkg/lvm
-	sudo ./lvm.test -test.v
-	go test -c -i ./pkg/csilvm
-	sudo ./csilvm.test -test.v
+	$(TEST_PREFIX) sh -c "go test -c -i ./pkg/lvm && ./lvm.test -test.v -test.run=${FILTER}"
+	$(TEST_PREFIX) sh -c "go test -c -i ./pkg/csilvm && ./csilvm.test -test.v -test.run=${FILTER}"

--- a/pkg/csilvm/mount_test.go
+++ b/pkg/csilvm/mount_test.go
@@ -1,0 +1,46 @@
+package csilvm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseMountinfoOptionalFields(t *testing.T) {
+	buf := []byte("36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue")
+	mounts, err := parseMountinfo(buf)
+	if err != nil {
+		panic(err)
+	}
+	exp := []mountpoint{
+		{
+			root:        "/mnt1",
+			path:        "/mnt2",
+			fstype:      "ext3",
+			mountopts:   []string{"rw", "noatime"},
+			mountsource: "/dev/root",
+		},
+	}
+	if !reflect.DeepEqual(mounts, exp) {
+		t.Fatalf("Expected %#v but got %#v", exp, mounts)
+	}
+}
+
+func TestParseMountinfoNoOptionalFields(t *testing.T) {
+	buf := []byte("228 381 253:4 / /mnt/volume-1 rw,relatime - xfs /mnt/volume-1 rw,seclabel,attr2,inode64,noquota")
+	mounts, err := parseMountinfo(buf)
+	if err != nil {
+		panic(err)
+	}
+	exp := []mountpoint{
+		{
+			root:        "/",
+			path:        "/mnt/volume-1",
+			fstype:      "xfs",
+			mountopts:   []string{"rw", "relatime"},
+			mountsource: "/mnt/volume-1",
+		},
+	}
+	if !reflect.DeepEqual(mounts, exp) {
+		t.Fatalf("Expected %#v but got %#v", exp, mounts)
+	}
+}


### PR DESCRIPTION
This PR modifies the `sudo-test` make target to run the tests in an appropriately bind-mounted docker.

It also fixes parsing of /proc/self/mountinfo which may have one or more optional fields. The user-facing effect of this fix is that under certain circumstances the second of two identical NodePublishVolume RPCs will fail where the second should have succeeded through idempotency, with a message saying that the mountpoint is already populated.

Fixes https://jira.mesosphere.com/browse/DSS_EE-17
Fixes https://jira.mesosphere.com/browse/DSS_EE-16