### PR TITLE
jenkins: abort lock if test run long, or jenkins freezes up [Backport 0.1]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,9 @@ ansiColor('xterm') {
         sh("make")
 
         lock(label: "linux-dev-loop") {
-          sh("make sudo-test")
+          timeout(30) {
+            sh("make sudo-test")
+          }
         }
       }
     }


### PR DESCRIPTION
This PR backports https://github.com/mesosphere/csilvm/commit/cc2f9e09e3451d98b6cd3a07ed46e42d5a03a2c2 to the `release-0.1` branch.