### PR TITLE
Add RAID support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 ansiColor('xterm') {
 
-  node("mesos-ec2-centos-7") {
+  node("mesos-ec2-ubuntu-16.04-raidmod") {
     properties([
       parameters([
         string(name: "SLACK_CREDENTIAL_ID", defaultValue: "25fe61e8-597e-430f-94bf-e58df726f9eb"),
@@ -19,7 +19,7 @@ ansiColor('xterm') {
     }
   }
 
-  node("mesos-ec2-centos-7") {
+  node("mesos-ec2-ubuntu-16.04-raidmod") {
     properties([
       parameters([
         string(name: "GITHUB_CREDENTIAL_ID", defaultValue: "d146870f-03b0-4f6a-ab70-1d09757a51fc"),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,9 +41,9 @@ ansiColor('xterm') {
         sh("sudo apt-get update")
         sh("sudo apt-get install -y lvm2 kmod")
 	// Load the raid1 module on the host.
-        sh("sudo /usr/sbin/modprobe raid1")
+        sh("sudo /sbin/modprobe raid1")
 	// Load the dm_raid module on the host.
-        sh("sudo /usr/sbin/modprobe dm_raid")
+        sh("sudo /sbin/modprobe dm_raid")
         sh("make check")
         sh("make")
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,8 @@ ansiColor('xterm') {
     stage("Build and Test") {
       withEnv(["DOCKER=yes"]) {
         // Install dependencies necessary to load raid-related kernel modules.
-        sh("sudo yum install -y lvm2 kmod")
+        sh("sudo apt-get update")
+        sh("sudo apt-get install -y lvm2 kmod")
 	// Load the raid1 module on the host.
         sh("sudo /usr/sbin/modprobe raid1")
 	// Load the dm_raid module on the host.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 ansiColor('xterm') {
 
-  node("mesos-ubuntu") {
+  node("mesos-ec2-centos-7") {
     properties([
       parameters([
         string(name: "SLACK_CREDENTIAL_ID", defaultValue: "25fe61e8-597e-430f-94bf-e58df726f9eb"),
@@ -19,7 +19,7 @@ ansiColor('xterm') {
     }
   }
 
-  node("mesos-ubuntu") {
+  node("mesos-ec2-centos-7") {
     properties([
       parameters([
         string(name: "GITHUB_CREDENTIAL_ID", defaultValue: "d146870f-03b0-4f6a-ab70-1d09757a51fc"),
@@ -37,6 +37,12 @@ ansiColor('xterm') {
 
     stage("Build and Test") {
       withEnv(["DOCKER=yes"]) {
+        // Install dependencies necessary to load raid-related kernel modules.
+        sh("sudo yum install -y lvm2 kmod")
+	// Load the raid1 module on the host.
+        sh("sudo /usr/sbin/modprobe raid1")
+	// Load the dm_raid module on the host.
+        sh("sudo /usr/sbin/modprobe dm_raid")
         sh("make check")
         sh("make")
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,12 +37,6 @@ ansiColor('xterm') {
 
     stage("Build and Test") {
       withEnv(["DOCKER=yes"]) {
-        // Install dependencies necessary to load raid-related kernel modules.
-        sh("sudo yum install -y lvm2 kmod")
-	// Load the raid1 module on the host.
-        sh("sudo /usr/sbin/modprobe raid1")
-	// Load the dm_raid module on the host.
-        sh("sudo /usr/sbin/modprobe dm_raid")
         sh("make check")
         sh("make")
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,12 @@ ansiColor('xterm') {
 
     stage("Build and Test") {
       withEnv(["DOCKER=yes"]) {
+        // Install dependencies necessary to load raid-related kernel modules.
+        sh("sudo yum install -y lvm2 kmod")
+	// Load the raid1 module on the host.
+        sh("sudo /usr/sbin/modprobe raid1")
+	// Load the dm_raid module on the host.
+        sh("sudo /usr/sbin/modprobe dm_raid")
         sh("make check")
         sh("make")
 

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -587,7 +587,9 @@ func TestCreateVolume_RAIDConfig_TooFewDisks(t *testing.T) {
 		"type": "raid1",
 	}
 	_, err := client.CreateVolume(context.Background(), req)
-	if !grpcErrorEqual(err, ErrTooFewDisks) {
+	if !grpcErrorEqual(err, ErrInsufficientCapacity) {
+		// We expect ErrInsufficientCapacity as CreateVolume checks
+		// whether there is sufficient capacity to create the volume.
 		t.Fatal(err)
 	}
 }

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -489,7 +489,7 @@ func TestCreateVolumeInvalidVolumeName(t *testing.T) {
 	}
 }
 
-func TestCreateVolume_RAIDConfig_Linear(t *testing.T) {
+func TestCreateVolume_VolumeLayout_Linear(t *testing.T) {
 	vgname := testvgname()
 	pvname, pvclean := testpv()
 	defer pvclean()
@@ -510,12 +510,9 @@ func TestCreateVolume_RAIDConfig_Linear(t *testing.T) {
 	if !strings.HasSuffix(info.GetId(), req.GetName()) {
 		t.Fatalf("Expected volume ID (%v) to name as a suffix (%v).", info.GetId(), req.GetName())
 	}
-	if !reflect.DeepEqual(req.GetParameters(), resp.GetVolume().GetAttributes()) {
-		t.Fatalf("Expected volume attributes to match parameters")
-	}
 }
 
-func TestCreateVolume_RAIDConfig_RAID1(t *testing.T) {
+func TestCreateVolume_VolumeLayout_RAID1(t *testing.T) {
 	vgname := testvgname()
 	pvname1, pvclean1 := testpv()
 	defer pvclean1()
@@ -538,12 +535,9 @@ func TestCreateVolume_RAIDConfig_RAID1(t *testing.T) {
 	if !strings.HasSuffix(info.GetId(), req.GetName()) {
 		t.Fatalf("Expected volume ID (%v) to name as a suffix (%v).", info.GetId(), req.GetName())
 	}
-	if !reflect.DeepEqual(req.GetParameters(), resp.GetVolume().GetAttributes()) {
-		t.Fatalf("Expected volume attributes to match parameters")
-	}
 }
 
-func TestCreateVolume_RAIDConfig_RAID1_Mirror2(t *testing.T) {
+func TestCreateVolume_VolumeLayout_RAID1_Mirror2(t *testing.T) {
 	vgname := testvgname()
 	pvname1, pvclean1 := testpv()
 	defer pvclean1()
@@ -571,12 +565,9 @@ func TestCreateVolume_RAIDConfig_RAID1_Mirror2(t *testing.T) {
 	if !strings.HasSuffix(info.GetId(), req.GetName()) {
 		t.Fatalf("Expected volume ID (%v) to name as a suffix (%v).", info.GetId(), req.GetName())
 	}
-	if !reflect.DeepEqual(req.GetParameters(), resp.GetVolume().GetAttributes()) {
-		t.Fatalf("Expected volume attributes to match parameters")
-	}
 }
 
-func TestCreateVolume_RAIDConfig_TooFewDisks(t *testing.T) {
+func TestCreateVolume_VolumeLayout_TooFewDisks(t *testing.T) {
 	vgname := testvgname()
 	pvname, pvclean := testpv()
 	defer pvclean()
@@ -1127,11 +1118,11 @@ func (tc testGetCapacity) test(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	raid, err := takeRAIDConfigFromParameters(dupParams(req.GetParameters()))
+	layout, err := takeVolumeLayoutFromParameters(dupParams(req.GetParameters()))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if raid.NumberOfDevices() > tc.numberOfPVs {
+	if layout.MinNumberOfDevices() > tc.numberOfPVs {
 		if resp.GetAvailableCapacity() != 0 {
 			t.Fatalf("Expected 0 bytes free.")
 		}
@@ -1165,7 +1156,7 @@ func TestGetCapacity_NoVolumes(t *testing.T) {
 	}.test(t)
 }
 
-func TestGetCapacity_NoVolumes_OneDisk_RAIDConfig_Linear(t *testing.T) {
+func TestGetCapacity_NoVolumes_OneDisk_VolumeLayout_Linear(t *testing.T) {
 	testGetCapacity{
 		numberOfPVs:  1,
 		params:       map[string]string{"type": "linear"},
@@ -1173,7 +1164,7 @@ func TestGetCapacity_NoVolumes_OneDisk_RAIDConfig_Linear(t *testing.T) {
 	}.test(t)
 }
 
-func TestGetCapacity_NoVolumes_OneDisk_RAIDConfig_RAID1(t *testing.T) {
+func TestGetCapacity_NoVolumes_OneDisk_VolumeLayout_RAID1(t *testing.T) {
 	testGetCapacity{
 		numberOfPVs:  1,
 		params:       map[string]string{"type": "raid1"},
@@ -1181,7 +1172,7 @@ func TestGetCapacity_NoVolumes_OneDisk_RAIDConfig_RAID1(t *testing.T) {
 	}.test(t)
 }
 
-func TestGetCapacity_NoVolumes_TwoDisks_RAIDConfig_RAID1(t *testing.T) {
+func TestGetCapacity_NoVolumes_TwoDisks_VolumeLayout_RAID1(t *testing.T) {
 	testGetCapacity{
 		numberOfPVs:  2,
 		params:       map[string]string{"type": "raid1"},
@@ -1189,7 +1180,7 @@ func TestGetCapacity_NoVolumes_TwoDisks_RAIDConfig_RAID1(t *testing.T) {
 	}.test(t)
 }
 
-func TestGetCapacity_NoVolumes_FourDisks_RAIDConfig_RAID1_Mirrors2(t *testing.T) {
+func TestGetCapacity_NoVolumes_FourDisks_VolumeLayout_RAID1_Mirrors2(t *testing.T) {
 	testGetCapacity{
 		numberOfPVs:  4,
 		params:       map[string]string{"type": "raid1", "mirrors": "2"},
@@ -1205,7 +1196,7 @@ func TestGetCapacity_OneVolume(t *testing.T) {
 	}.test(t)
 }
 
-func TestGetCapacity_OneVolume_RAIDConfig_Linear(t *testing.T) {
+func TestGetCapacity_OneVolume_VolumeLayout_Linear(t *testing.T) {
 	testGetCapacity{
 		numberOfPVs:  1,
 		params:       map[string]string{"type": "linear"},
@@ -1213,7 +1204,7 @@ func TestGetCapacity_OneVolume_RAIDConfig_Linear(t *testing.T) {
 	}.test(t)
 }
 
-func TestGetCapacity_OneVolume_TwoDisks_RAIDConfig_RAID1(t *testing.T) {
+func TestGetCapacity_OneVolume_TwoDisks_VolumeLayout_RAID1(t *testing.T) {
 	testGetCapacity{
 		numberOfPVs:  2,
 		params:       map[string]string{"type": "linear"},
@@ -1221,7 +1212,7 @@ func TestGetCapacity_OneVolume_TwoDisks_RAIDConfig_RAID1(t *testing.T) {
 	}.test(t)
 }
 
-func TestGetCapacity_OneVolume_FourDisks_RAIDConfig_Mirror2(t *testing.T) {
+func TestGetCapacity_OneVolume_FourDisks_VolumeLayout_Mirror2(t *testing.T) {
 	testGetCapacity{
 		numberOfPVs:  2,
 		params:       map[string]string{"type": "raid1", "mirrors": "2"},

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -489,6 +489,109 @@ func TestCreateVolumeInvalidVolumeName(t *testing.T) {
 	}
 }
 
+func TestCreateVolume_RAIDConfig_Linear(t *testing.T) {
+	vgname := testvgname()
+	pvname, pvclean := testpv()
+	defer pvclean()
+	client, clean := startTest(vgname, []string{pvname})
+	defer clean()
+	req := testCreateVolumeRequest()
+	req.Parameters = map[string]string{
+		"type": "linear",
+	}
+	resp, err := client.CreateVolume(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := resp.GetVolume()
+	if info.GetCapacityBytes() != req.GetCapacityRange().GetRequiredBytes() {
+		t.Fatalf("Expected required_bytes (%v) to match volume size (%v).", req.GetCapacityRange().GetRequiredBytes(), info.GetCapacityBytes())
+	}
+	if !strings.HasSuffix(info.GetId(), req.GetName()) {
+		t.Fatalf("Expected volume ID (%v) to name as a suffix (%v).", info.GetId(), req.GetName())
+	}
+	if !reflect.DeepEqual(req.GetParameters(), resp.GetVolume().GetAttributes()) {
+		t.Fatalf("Expected volume attributes to match parameters")
+	}
+}
+
+func TestCreateVolume_RAIDConfig_RAID1(t *testing.T) {
+	vgname := testvgname()
+	pvname1, pvclean1 := testpv()
+	defer pvclean1()
+	pvname2, pvclean2 := testpv()
+	defer pvclean2()
+	client, clean := startTest(vgname, []string{pvname1, pvname2})
+	defer clean()
+	req := testCreateVolumeRequest()
+	req.Parameters = map[string]string{
+		"type": "raid1",
+	}
+	resp, err := client.CreateVolume(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := resp.GetVolume()
+	if info.GetCapacityBytes() != req.GetCapacityRange().GetRequiredBytes() {
+		t.Fatalf("Expected required_bytes (%v) to match volume size (%v).", req.GetCapacityRange().GetRequiredBytes(), info.GetCapacityBytes())
+	}
+	if !strings.HasSuffix(info.GetId(), req.GetName()) {
+		t.Fatalf("Expected volume ID (%v) to name as a suffix (%v).", info.GetId(), req.GetName())
+	}
+	if !reflect.DeepEqual(req.GetParameters(), resp.GetVolume().GetAttributes()) {
+		t.Fatalf("Expected volume attributes to match parameters")
+	}
+}
+
+func TestCreateVolume_RAIDConfig_RAID1_Mirror2(t *testing.T) {
+	vgname := testvgname()
+	pvname1, pvclean1 := testpv()
+	defer pvclean1()
+	pvname2, pvclean2 := testpv()
+	defer pvclean2()
+	pvname3, pvclean3 := testpv()
+	defer pvclean3()
+	pvname4, pvclean4 := testpv()
+	defer pvclean4()
+	client, clean := startTest(vgname, []string{pvname1, pvname2, pvname3, pvname4})
+	defer clean()
+	req := testCreateVolumeRequest()
+	req.Parameters = map[string]string{
+		"type":    "raid1",
+		"mirrors": "2",
+	}
+	resp, err := client.CreateVolume(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := resp.GetVolume()
+	if info.GetCapacityBytes() != req.GetCapacityRange().GetRequiredBytes() {
+		t.Fatalf("Expected required_bytes (%v) to match volume size (%v).", req.GetCapacityRange().GetRequiredBytes(), info.GetCapacityBytes())
+	}
+	if !strings.HasSuffix(info.GetId(), req.GetName()) {
+		t.Fatalf("Expected volume ID (%v) to name as a suffix (%v).", info.GetId(), req.GetName())
+	}
+	if !reflect.DeepEqual(req.GetParameters(), resp.GetVolume().GetAttributes()) {
+		t.Fatalf("Expected volume attributes to match parameters")
+	}
+}
+
+func TestCreateVolume_RAIDConfig_TooFewDisks(t *testing.T) {
+	vgname := testvgname()
+	pvname, pvclean := testpv()
+	defer pvclean()
+	client, clean := startTest(vgname, []string{pvname})
+	defer clean()
+	req := testCreateVolumeRequest()
+	req.Parameters = map[string]string{
+		"type": "raid1",
+	}
+	_, err := client.CreateVolume(context.Background(), req)
+	if !grpcErrorEqual(err, ErrTooFewDisks) {
+		t.Fatal(err)
+	}
+}
+
 func testDeleteVolumeRequest(volumeId string) *csi.DeleteVolumeRequest {
 	req := &csi.DeleteVolumeRequest{
 		volumeId,
@@ -979,51 +1082,149 @@ func testGetCapacityRequest(fstype string) *csi.GetCapacityRequest {
 	return req
 }
 
-func TestGetCapacity_NoVolumes(t *testing.T) {
+type testGetCapacity struct {
+	numberOfPVs  uint64
+	params       map[string]string
+	createVolume bool
+	err          error
+}
+
+func (tc testGetCapacity) test(t *testing.T) {
 	vgname := testvgname()
-	pvname, pvclean := testpv()
-	defer pvclean()
-	client, clean := startTest(vgname, []string{pvname})
+	var pvnames []string
+	for ii := uint64(0); ii < tc.numberOfPVs; ii++ {
+		pvname, pvclean := testpv()
+		defer pvclean()
+		pvnames = append(pvnames, pvname)
+	}
+	client, clean := startTest(vgname, pvnames)
 	defer clean()
+	volumesize := int64(0)
+	if tc.createVolume {
+		volumesize = 40 << 20
+		createReq := testCreateVolumeRequest()
+		createReq.Name = "test-volume-1"
+		createReq.CapacityRange.RequiredBytes = volumesize
+		_, err := client.CreateVolume(context.Background(), createReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 	req := testGetCapacityRequest("xfs")
+	req.Parameters = map[string]string{
+		"type":    "raid1",
+		"mirrors": "2",
+	}
 	resp, err := client.GetCapacity(context.Background(), req)
+	if tc.err != nil {
+		if !grpcErrorEqual(err, tc.err) {
+			t.Fatal(err)
+		}
+		return
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Two extents are reserved for metadata.
-	const extentSize = uint64(2 << 20)
-	const metadataExtents = 2
-	exp := pvsize - extentSize*metadataExtents
-	if got := resp.GetAvailableCapacity(); got != int64(exp) {
-		t.Fatalf("Expected %d bytes free but got %v.", exp, got)
+	raid, err := takeRAIDConfigFromParameters(dupParams(req.GetParameters()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raid.NumberOfDevices() > tc.numberOfPVs {
+		if resp.GetAvailableCapacity() != 0 {
+			t.Fatalf("Expected 0 bytes free.")
+		}
+		return
+	}
+	const extentsize = uint64(4 << 20)
+	// One extent per PV is reserved for metadata.
+	metadataExtents := tc.numberOfPVs
+	// Calculate the linear available capacity.
+	totalExtents := tc.numberOfPVs * pvsize / extentsize
+	// Subtract the per-PV metadata extents from the total expected number of extents.
+	totalAvailableExtents := totalExtents - metadataExtents
+	// Reduce the capacity by the required_bytes of the created volume (if any).
+	linearAvailableExtents := totalAvailableExtents - uint64(volumesize)/extentsize
+	// Reduce the capacity by one more extent per data copy as each needs
+	// to store metadata in a single extent. Then divide the remaining extents
+	// by the number of data copies.
+	expextents := (linearAvailableExtents - 3) / 3
+	// The remaining bytes we get by multiplying by the extentsize again.
+	expbytes := expextents * extentsize
+	if got := resp.GetAvailableCapacity(); uint64(got) != expbytes {
+		t.Fatalf("Expected %d bytes free but got %v.", expbytes, got)
 	}
 }
 
+func TestGetCapacity_NoVolumes(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  1,
+		params:       nil,
+		createVolume: false,
+	}.test(t)
+}
+
+func TestGetCapacity_NoVolumes_OneDisk_RAIDConfig_Linear(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  1,
+		params:       map[string]string{"type": "linear"},
+		createVolume: false,
+	}.test(t)
+}
+
+func TestGetCapacity_NoVolumes_OneDisk_RAIDConfig_RAID1(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  1,
+		params:       map[string]string{"type": "raid1"},
+		createVolume: false,
+	}.test(t)
+}
+
+func TestGetCapacity_NoVolumes_TwoDisks_RAIDConfig_RAID1(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  2,
+		params:       map[string]string{"type": "raid1"},
+		createVolume: false,
+	}.test(t)
+}
+
+func TestGetCapacity_NoVolumes_FourDisks_RAIDConfig_RAID1_Mirrors2(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  4,
+		params:       map[string]string{"type": "raid1", "mirrors": "2"},
+		createVolume: false,
+	}.test(t)
+}
+
 func TestGetCapacity_OneVolume(t *testing.T) {
-	vgname := testvgname()
-	pvname, pvclean := testpv()
-	defer pvclean()
-	client, clean := startTest(vgname, []string{pvname})
-	defer clean()
-	createReq := testCreateVolumeRequest()
-	createReq.Name = "test-volume-1"
-	createReq.CapacityRange.RequiredBytes /= 2
-	_, err := client.CreateVolume(context.Background(), createReq)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req := testGetCapacityRequest("xfs")
-	resp, err := client.GetCapacity(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Two extents are reserved for metadata.
-	const extentSize = int64(2 << 20)
-	const metadataExtents = 2
-	exp := int64(pvsize) - extentSize*metadataExtents - createReq.CapacityRange.RequiredBytes
-	if got := resp.GetAvailableCapacity(); got != exp {
-		t.Fatalf("Expected %d bytes free but got %v.", exp, got)
-	}
+	testGetCapacity{
+		numberOfPVs:  1,
+		params:       nil,
+		createVolume: true,
+	}.test(t)
+}
+
+func TestGetCapacity_OneVolume_RAIDConfig_Linear(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  1,
+		params:       map[string]string{"type": "linear"},
+		createVolume: true,
+	}.test(t)
+}
+
+func TestGetCapacity_OneVolume_TwoDisks_RAIDConfig_RAID1(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  2,
+		params:       map[string]string{"type": "linear"},
+		createVolume: true,
+	}.test(t)
+}
+
+func TestGetCapacity_OneVolume_FourDisks_RAIDConfig_Mirror2(t *testing.T) {
+	testGetCapacity{
+		numberOfPVs:  2,
+		params:       map[string]string{"type": "raid1", "mirrors": "2"},
+		createVolume: true,
+	}.test(t)
 }
 
 func TestGetCapacity_RemoveVolumeGroup(t *testing.T) {

--- a/pkg/csilvm/validate_test.go
+++ b/pkg/csilvm/validate_test.go
@@ -441,7 +441,5 @@ func grpcErrorEqual(gotErr, expErr error) bool {
 
 func startTestValidate(serverOpts ...ServerOpt) (client *Client, cleanupFn func()) {
 	vgname := testvgname()
-	pvname, pvclean := testpv()
-	defer pvclean()
-	return startTest(vgname, []string{pvname}, serverOpts...)
+	return startTest(vgname, nil, serverOpts...)
 }

--- a/pkg/lvm/lvm_test.go
+++ b/pkg/lvm/lvm_test.go
@@ -373,7 +373,7 @@ func TestVolumeGroupBytesFree(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +399,7 @@ func TestCreateLogicalVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func TestCreateLogicalVolume_Tagged(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestCreateLogicalVolume_BadTag(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -483,7 +483,7 @@ func TestCreateLogicalVolumeDuplicateNameIsAllowed(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg1.BytesFree(RAIDConfig{})
+	size, err := vg1.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,7 +498,7 @@ func TestCreateLogicalVolumeDuplicateNameIsAllowed(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err = vg2.BytesFree(RAIDConfig{})
+	size, err = vg2.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +520,7 @@ func TestCreateLogicalVolumeInvalidName(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -546,7 +546,7 @@ func TestCreateLogicalVolumeTooLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,7 +561,7 @@ func TestCreateLogicalVolumeTooLarge(t *testing.T) {
 	}
 }
 
-func TestCreateLogicalVolume_RAIDConfig_Empty(t *testing.T) {
+func TestCreateLogicalVolume_VolumeLayout_Empty(t *testing.T) {
 	loop, err := CreateLoopDevice(pvsize)
 	if err != nil {
 		t.Fatal(err)
@@ -572,14 +572,14 @@ func TestCreateLogicalVolume_RAIDConfig_Empty(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	raid := RAIDConfig{}
+	raid := VolumeLayout{}
 	size, err := vg.BytesFree(raid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	name := "test-lv-" + uuid.New().String()
 	tag := "dcos-tag"
-	lv, err := vg.CreateLogicalVolume(name, size, []string{tag}, RAIDOpt(raid))
+	lv, err := vg.CreateLogicalVolume(name, size, []string{tag}, VolumeLayoutOpt(raid))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func TestCreateLogicalVolume_RAIDConfig_Empty(t *testing.T) {
 	}
 }
 
-func TestCreateLogicalVolume_RAIDConfig_Linear(t *testing.T) {
+func TestCreateLogicalVolume_VolumeLayout_Linear(t *testing.T) {
 	loop, err := CreateLoopDevice(pvsize)
 	if err != nil {
 		t.Fatal(err)
@@ -604,14 +604,14 @@ func TestCreateLogicalVolume_RAIDConfig_Linear(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	raid := RAIDConfig{Type: VolumeTypeLinear}
+	raid := VolumeLayout{Type: VolumeTypeLinear}
 	size, err := vg.BytesFree(raid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	name := "test-lv-" + uuid.New().String()
 	tag := "dcos-tag"
-	lv, err := vg.CreateLogicalVolume(name, size, []string{tag}, RAIDOpt(raid))
+	lv, err := vg.CreateLogicalVolume(name, size, []string{tag}, VolumeLayoutOpt(raid))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,7 +625,7 @@ func TestCreateLogicalVolume_RAIDConfig_Linear(t *testing.T) {
 	}
 }
 
-func TestCreateLogicalVolume_RAIDConfig_RAID1(t *testing.T) {
+func TestCreateLogicalVolume_VolumeLayout_RAID1(t *testing.T) {
 	loop1, err := CreateLoopDevice(pvsize)
 	if err != nil {
 		t.Fatal(err)
@@ -641,14 +641,14 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	raid := RAIDConfig{Type: VolumeTypeRAID1}
+	raid := VolumeLayout{Type: VolumeTypeRAID1}
 	size, err := vg.BytesFree(raid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	name := "test-lv-" + uuid.New().String()
 	tag := "dcos-tag"
-	lv, err := vg.CreateLogicalVolume(name, size/2, []string{tag}, RAIDOpt(raid))
+	lv, err := vg.CreateLogicalVolume(name, size/2, []string{tag}, VolumeLayoutOpt(raid))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -662,7 +662,7 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1(t *testing.T) {
 	}
 }
 
-func TestCreateLogicalVolume_RAIDConfig_RAID1_Mirrors2(t *testing.T) {
+func TestCreateLogicalVolume_VolumeLayout_RAID1_Mirrors2(t *testing.T) {
 	loop1, err := CreateLoopDevice(pvsize)
 	if err != nil {
 		t.Fatal(err)
@@ -688,14 +688,14 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1_Mirrors2(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	raid := RAIDConfig{Type: VolumeTypeRAID1, Mirrors: 2}
+	raid := VolumeLayout{Type: VolumeTypeRAID1, Mirrors: 2}
 	size, err := vg.BytesFree(raid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	name := "test-lv-" + uuid.New().String()
 	tag := "dcos-tag"
-	lv, err := vg.CreateLogicalVolume(name, size/4, []string{tag}, RAIDOpt(raid))
+	lv, err := vg.CreateLogicalVolume(name, size/4, []string{tag}, VolumeLayoutOpt(raid))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -709,7 +709,7 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1_Mirrors2(t *testing.T) {
 	}
 }
 
-func TestCreateLogicalVolume_RAIDConfig_RAID1_NotEnoughSpace(t *testing.T) {
+func TestCreateLogicalVolume_VolumeLayout_RAID1_NotEnoughSpace(t *testing.T) {
 	loop1, err := CreateLoopDevice(pvsize)
 	if err != nil {
 		t.Fatal(err)
@@ -725,14 +725,14 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1_NotEnoughSpace(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	raid := RAIDConfig{Type: VolumeTypeRAID1, Mirrors: 1}
+	raid := VolumeLayout{Type: VolumeTypeRAID1, Mirrors: 1}
 	size, err := vg.BytesFree(raid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	name := "test-lv-" + uuid.New().String()
 	tag := "dcos-tag"
-	lv, err := vg.CreateLogicalVolume(name, size*2, []string{tag}, RAIDOpt(raid))
+	lv, err := vg.CreateLogicalVolume(name, size*2, []string{tag}, VolumeLayoutOpt(raid))
 	if err == nil {
 		defer lv.Remove()
 		t.Fatalf("Expected error due to too few disks")
@@ -742,7 +742,7 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1_NotEnoughSpace(t *testing.T) {
 	}
 }
 
-func TestCreateLogicalVolume_RAIDConfig_RAID1_TooFewDisks(t *testing.T) {
+func TestCreateLogicalVolume_VolumeLayout_RAID1_TooFewDisks(t *testing.T) {
 	loop, err := CreateLoopDevice(pvsize)
 	if err != nil {
 		t.Fatal(err)
@@ -758,8 +758,8 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1_TooFewDisks(t *testing.T) {
 	size := uint64(10 << 20)
 	name := "test-lv-" + uuid.New().String()
 	tag := "dcos-tag"
-	raid := RAIDConfig{Type: VolumeTypeRAID1, Mirrors: 1}
-	lv, err := vg.CreateLogicalVolume(name, size, []string{tag}, RAIDOpt(raid))
+	raid := VolumeLayout{Type: VolumeTypeRAID1, Mirrors: 1}
+	lv, err := vg.CreateLogicalVolume(name, size, []string{tag}, VolumeLayoutOpt(raid))
 	if err == nil {
 		defer lv.Remove()
 		t.Fatalf("Expected error due to too few disks")
@@ -780,7 +780,7 @@ func TestLookupLogicalVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -810,7 +810,7 @@ func TestLookupLogicalVolumeNonExistent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -840,7 +840,7 @@ func TestLogicalVolumeName(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -866,7 +866,7 @@ func TestLogicalVolumeSizeInBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -899,7 +899,7 @@ func TestLogicalVolumePath(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -930,7 +930,7 @@ func TestVolumeGroupListLogicalVolumeNames(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	size, err := vg.BytesFree(RAIDConfig{})
+	size, err := vg.BytesFree(VolumeLayout{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/lvm/lvm_test.go
+++ b/pkg/lvm/lvm_test.go
@@ -753,16 +753,12 @@ func TestCreateLogicalVolume_RAIDConfig_RAID1_TooFewDisks(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	raid := RAIDConfig{Type: VolumeTypeRAID1, Mirrors: 1}
-	size, err := vg.BytesFree(raid)
-	if err != nil {
-		t.Fatal(err)
-	}
 	// Make sure there's enough space so we are sure we hit the issue with too
 	// few underlying disks, instead.
-	size = size / 2
+	size := uint64(10 << 20)
 	name := "test-lv-" + uuid.New().String()
 	tag := "dcos-tag"
+	raid := RAIDConfig{Type: VolumeTypeRAID1, Mirrors: 1}
 	lv, err := vg.CreateLogicalVolume(name, size, []string{tag}, RAIDOpt(raid))
 	if err == nil {
 		defer lv.Remove()


### PR DESCRIPTION
This PR adds RAID support. 

The `GetCapacity` and `CreateVolume` RPCs can now provide `type` and `mirrors` parameters. These correspond to lvm2's `lvcreate` command-line options of the same name. See the man page of `lvcreate` or `lvmraid` for more info.

There's definitely space for some more refactoring of test code. I did some in this PR. I'll come back for that soon.