### PR TITLE
csilvm: extract request validation into separate types

### DIFF
--- a/cmd/csilvm/csilvm.go
+++ b/cmd/csilvm/csilvm.go
@@ -87,8 +87,8 @@ func main() {
 	if err := s.Setup(); err != nil {
 		log.Fatalf("[%s] error initializing csilvm plugin: err=%v", *vgnameF, err)
 	}
-	csi.RegisterIdentityServer(grpcServer, s)
-	csi.RegisterControllerServer(grpcServer, s)
-	csi.RegisterNodeServer(grpcServer, s)
+	csi.RegisterIdentityServer(grpcServer, csilvm.IdentityServerValidator(s))
+	csi.RegisterControllerServer(grpcServer, csilvm.ControllerServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
+	csi.RegisterNodeServer(grpcServer, csilvm.NodeServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
 	grpcServer.Serve(lis)
 }

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -2623,9 +2623,9 @@ func prepareSetupTest(vgname string, pvnames []string, serverOpts ...ServerOpt) 
 	SetLogger(stdlog.New(os.Stderr, logprefix, logflags))
 	// Start a grpc server listening on the socket.
 	grpcServer := grpc.NewServer(opts...)
-	csi.RegisterIdentityServer(grpcServer, s)
-	csi.RegisterControllerServer(grpcServer, s)
-	csi.RegisterNodeServer(grpcServer, s)
+	csi.RegisterIdentityServer(grpcServer, csilvm.IdentityServerValidator(s))
+	csi.RegisterControllerServer(grpcServer, csilvm.ControllerServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
+	csi.RegisterNodeServer(grpcServer, csilvm.NodeServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
 	go grpcServer.Serve(lis)
 
 	// Start a grpc client connected to the server.

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -2623,9 +2623,9 @@ func prepareSetupTest(vgname string, pvnames []string, serverOpts ...ServerOpt) 
 	SetLogger(stdlog.New(os.Stderr, logprefix, logflags))
 	// Start a grpc server listening on the socket.
 	grpcServer := grpc.NewServer(opts...)
-	csi.RegisterIdentityServer(grpcServer, csilvm.IdentityServerValidator(s))
-	csi.RegisterControllerServer(grpcServer, csilvm.ControllerServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
-	csi.RegisterNodeServer(grpcServer, csilvm.NodeServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
+	csi.RegisterIdentityServer(grpcServer, IdentityServerValidator(s))
+	csi.RegisterControllerServer(grpcServer, ControllerServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
+	csi.RegisterNodeServer(grpcServer, NodeServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
 	go grpcServer.Serve(lis)
 
 	// Start a grpc client connected to the server.

--- a/pkg/csilvm/validate.go
+++ b/pkg/csilvm/validate.go
@@ -1,6 +1,8 @@
 package csilvm
 
 import (
+	"context"
+
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -10,22 +12,190 @@ var ErrRemovingMode = status.Error(
 	codes.FailedPrecondition,
 	"This service is running in 'remove volume group' mode.")
 
-func (s *Server) validateRemoving() error {
-	if s.removingVolumeGroup {
+func validateRemoving(removingVolumeGroup bool) error {
+	if removingVolumeGroup {
 		return ErrRemovingMode
+	}
+	return nil
+}
+
+// IdentityService RPCs
+
+type identityServerValidator struct {
+	inner csi.IdentityServer
+}
+
+func IdentityServerValidator(inner csi.IdentityServer) csi.IdentityServer {
+	return &identityServerValidator{inner}
+}
+
+func (v *identityServerValidator) GetPluginInfo(
+	ctx context.Context,
+	request *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+	if err := validateGetPluginInfoRequest(request); err != nil {
+		return nil, err
+	}
+	return v.inner.GetPluginInfo(ctx, request)
+}
+
+func validateGetPluginInfoRequest(request *csi.GetPluginInfoRequest) error {
+	return nil
+}
+
+func (v *identityServerValidator) GetPluginCapabilities(
+	ctx context.Context,
+	request *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	if err := validateGetPluginCapabilitiesRequest(request); err != nil {
+		return nil, err
+	}
+	return v.inner.GetPluginCapabilities(ctx, request)
+}
+
+func validateGetPluginCapabilitiesRequest(request *csi.GetPluginCapabilitiesRequest) error {
+	return nil
+}
+
+func (v *identityServerValidator) Probe(
+	ctx context.Context,
+	request *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	if err := validateProbeRequest(request); err != nil {
+		return nil, err
+	}
+	return v.Probe(ctx, request)
+}
+
+func validateProbeRequest(request *csi.ProbeRequest) error {
+	return nil
+}
+
+// ControllerService RPCs
+
+type controllerServerValidator struct {
+	inner                csi.ControllerServer
+	removingVolumeGroup  bool
+	supportedFilesystems map[string]string
+}
+
+func ControllerServerValidator(inner csi.ControllerServer, removingVolumeGroup bool, supportedFilesystems map[string]string) csi.ControllerServer {
+	return &controllerServerValidator{inner, removingVolumeGroup, supportedFilesystems}
+}
+
+func (v *controllerServerValidator) CreateVolume(
+	ctx context.Context,
+	request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	if err := validateCreateVolumeRequest(request, v.removingVolumeGroup, v.supportedFilesystems); err != nil {
+		return nil, err
+	}
+	return v.inner.CreateVolume(ctx, request)
+}
+
+func validateCreateVolumeRequest(request *csi.CreateVolumeRequest, removingVolumeGroup bool, supportedFilesystems map[string]string) error {
+	if err := validateRemoving(removingVolumeGroup); err != nil {
+		return err
+	}
+	name := request.GetName()
+	if name == "" {
+		return ErrMissingName
+	}
+	if capacityRange := request.GetCapacityRange(); capacityRange != nil {
+		if err := validateCapacityRange(capacityRange); err != nil {
+			return err
+		}
+	}
+	if err := validateVolumeCapabilities(request.GetVolumeCapabilities(), supportedFilesystems); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *controllerServerValidator) DeleteVolume(
+	ctx context.Context,
+	request *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	if err := validateDeleteVolumeRequest(request, v.removingVolumeGroup); err != nil {
+		return nil, err
+	}
+	return v.inner.DeleteVolume(ctx, request)
+}
+
+var ErrMissingVolumeId = status.Error(codes.InvalidArgument, "The volume_id field must be specified.")
+
+func validateDeleteVolumeRequest(request *csi.DeleteVolumeRequest, removingVolumeGroup bool) error {
+	if err := validateRemoving(removingVolumeGroup); err != nil {
+		return err
+	}
+	volumeId := request.GetVolumeId()
+	if volumeId == "" {
+		return ErrMissingVolumeId
+	}
+	return nil
+}
+
+var ErrMissingName = status.Error(codes.InvalidArgument, "The name field must be specified.")
+var ErrUnsupportedFilesystem = status.Error(codes.FailedPrecondition, "The requested filesystem type is unknown.")
+
+var ErrCapacityRangeUnspecified = status.Error(
+	codes.InvalidArgument,
+	"One of required_bytes or limit_bytes must"+
+		"be specified if capacity_range is specified.")
+
+var ErrCapacityRangeInvalidSize = status.Error(
+	codes.InvalidArgument,
+	"The required_bytes cannot exceed the limit_bytes.")
+
+func validateCapacityRange(capacityRange *csi.CapacityRange) error {
+	if capacityRange.GetRequiredBytes() == 0 && capacityRange.GetLimitBytes() == 0 {
+		return ErrCapacityRangeUnspecified
+	}
+	if capacityRange.GetRequiredBytes() > capacityRange.GetLimitBytes() {
+		return ErrCapacityRangeInvalidSize
+	}
+	return nil
+}
+
+func (v *controllerServerValidator) ControllerPublishVolume(
+	ctx context.Context,
+	request *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	return v.inner.ControllerPublishVolume(ctx, request)
+}
+
+func (v *controllerServerValidator) ControllerUnpublishVolume(
+	ctx context.Context,
+	request *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	return v.inner.ControllerUnpublishVolume(ctx, request)
+}
+
+func (v *controllerServerValidator) ValidateVolumeCapabilities(
+	ctx context.Context,
+	request *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	if err := validateValidateVolumeCapabilitiesRequest(request, v.removingVolumeGroup, v.supportedFilesystems); err != nil {
+		return nil, err
+	}
+	return v.inner.ValidateVolumeCapabilities(ctx, request)
+}
+
+func validateValidateVolumeCapabilitiesRequest(request *csi.ValidateVolumeCapabilitiesRequest, removingVolumeGroup bool, supportedFilesystems map[string]string) error {
+	if err := validateRemoving(removingVolumeGroup); err != nil {
+		return err
+	}
+	volumeId := request.GetVolumeId()
+	if volumeId == "" {
+		return ErrMissingVolumeId
+	}
+	if err := validateVolumeCapabilities(request.GetVolumeCapabilities(), supportedFilesystems); err != nil {
+		return err
 	}
 	return nil
 }
 
 var ErrMissingVolumeCapabilities = status.Error(codes.InvalidArgument, "The volume_capabilities field must be specified.")
 
-func (s *Server) validateVolumeCapabilities(volumeCapabilities []*csi.VolumeCapability) error {
+func validateVolumeCapabilities(volumeCapabilities []*csi.VolumeCapability, supportedFilesystems map[string]string) error {
 	if len(volumeCapabilities) == 0 {
 		return ErrMissingVolumeCapabilities
 	}
 	for _, volumeCapability := range volumeCapabilities {
 		const treatUnsupportedFsAsError = false
-		if err := s.validateVolumeCapability(volumeCapability, treatUnsupportedFsAsError, false); err != nil {
+		if err := validateVolumeCapability(volumeCapability, supportedFilesystems, treatUnsupportedFsAsError, false); err != nil {
 			return err
 		}
 	}
@@ -51,7 +221,7 @@ var ErrBlockVolNoRO = status.Error(
 	codes.InvalidArgument,
 	"Cannot publish block volume as readonly.")
 
-func (s *Server) validateVolumeCapability(volumeCapability *csi.VolumeCapability, unsupportedFsOK, readonly bool) error {
+func validateVolumeCapability(volumeCapability *csi.VolumeCapability, supportedFilesystems map[string]string, unsupportedFsOK, readonly bool) error {
 	accessType := volumeCapability.GetAccessType()
 	if accessType == nil {
 		return ErrMissingAccessType
@@ -61,7 +231,7 @@ func (s *Server) validateVolumeCapability(volumeCapability *csi.VolumeCapability
 		fstype := mnt.GetFsType()
 		// If unsupportedFsOK is true, we don't treat an unsupported
 		// filesystem as an error.
-		if _, ok := s.supportedFilesystems[fstype]; !ok && !unsupportedFsOK {
+		if _, ok := supportedFilesystems[fstype]; !ok && !unsupportedFsOK {
 			return ErrUnsupportedFilesystem
 		}
 	}
@@ -95,115 +265,81 @@ func (s *Server) validateVolumeCapability(volumeCapability *csi.VolumeCapability
 	return nil
 }
 
-// IdentityService RPCs
+func (v *controllerServerValidator) ListVolumes(
+	ctx context.Context,
+	request *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	if err := validateListVolumesRequest(request); err != nil {
+		return nil, err
+	}
+	return v.inner.ListVolumes(ctx, request)
+}
 
-func (s *Server) validateGetPluginInfoRequest(request *csi.GetPluginInfoRequest) error {
+func validateListVolumesRequest(request *csi.ListVolumesRequest) error {
 	return nil
 }
 
-func (s *Server) validateGetPluginCapabilitiesRequest(request *csi.GetPluginCapabilitiesRequest) error {
-	return nil
+func (v *controllerServerValidator) GetCapacity(
+	ctx context.Context,
+	request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+	if err := validateGetCapacityRequest(request, v.supportedFilesystems); err != nil {
+		return nil, err
+	}
+	return v.inner.GetCapacity(ctx, request)
 }
 
-// ControllerService RPCs
-
-var ErrMissingName = status.Error(codes.InvalidArgument, "The name field must be specified.")
-var ErrUnsupportedFilesystem = status.Error(codes.FailedPrecondition, "The requested filesystem type is unknown.")
-
-func (s *Server) validateCreateVolumeRequest(request *csi.CreateVolumeRequest) error {
-	if err := s.validateRemoving(); err != nil {
-		return err
-	}
-	name := request.GetName()
-	if name == "" {
-		return ErrMissingName
-	}
-	if capacityRange := request.GetCapacityRange(); capacityRange != nil {
-		if err := s.validateCapacityRange(capacityRange); err != nil {
-			return err
-		}
-	}
-	if err := s.validateVolumeCapabilities(request.GetVolumeCapabilities()); err != nil {
-		return err
-	}
-	return nil
-}
-
-var ErrCapacityRangeUnspecified = status.Error(
-	codes.InvalidArgument,
-	"One of required_bytes or limit_bytes must"+
-		"be specified if capacity_range is specified.")
-
-var ErrCapacityRangeInvalidSize = status.Error(
-	codes.InvalidArgument,
-	"The required_bytes cannot exceed the limit_bytes.")
-
-func (s *Server) validateCapacityRange(capacityRange *csi.CapacityRange) error {
-	if capacityRange.GetRequiredBytes() == 0 && capacityRange.GetLimitBytes() == 0 {
-		return ErrCapacityRangeUnspecified
-	}
-	if capacityRange.GetRequiredBytes() > capacityRange.GetLimitBytes() {
-		return ErrCapacityRangeInvalidSize
-	}
-	return nil
-}
-
-var ErrMissingVolumeId = status.Error(codes.InvalidArgument, "The volume_id field must be specified.")
-
-func (s *Server) validateDeleteVolumeRequest(request *csi.DeleteVolumeRequest) error {
-	if err := s.validateRemoving(); err != nil {
-		return err
-	}
-	volumeId := request.GetVolumeId()
-	if volumeId == "" {
-		return ErrMissingVolumeId
-	}
-	return nil
-}
-
-func (s *Server) validateValidateVolumeCapabilitiesRequest(request *csi.ValidateVolumeCapabilitiesRequest) error {
-	if err := s.validateRemoving(); err != nil {
-		return err
-	}
-	volumeId := request.GetVolumeId()
-	if volumeId == "" {
-		return ErrMissingVolumeId
-	}
-	if err := s.validateVolumeCapabilities(request.GetVolumeCapabilities()); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s *Server) validateListVolumesRequest(request *csi.ListVolumesRequest) error {
-	return nil
-}
-
-func (s *Server) validateGetCapacityRequest(request *csi.GetCapacityRequest) error {
+func validateGetCapacityRequest(request *csi.GetCapacityRequest, supportedFilesystems map[string]string) error {
 	// If they are provided, the individual volume capabilities must be validated.
 	for _, volumeCapability := range request.GetVolumeCapabilities() {
 		// We don't treat "unsupported fs type" as an error for
 		// GetCapacity. We'll just return 0 capacity.
 		const ignoreUnsupportedFs = true
-		if err := s.validateVolumeCapability(volumeCapability, ignoreUnsupportedFs, false); err != nil {
+		if err := validateVolumeCapability(volumeCapability, supportedFilesystems, ignoreUnsupportedFs, false); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Server) validateControllerGetCapabilitiesRequest(request *csi.ControllerGetCapabilitiesRequest) error {
+func (v *controllerServerValidator) ControllerGetCapabilities(
+	ctx context.Context,
+	request *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+	if err := validateControllerGetCapabilitiesRequest(request); err != nil {
+		return nil, err
+	}
+	return v.ControllerGetCapabilities(ctx, request)
+}
+
+func validateControllerGetCapabilitiesRequest(request *csi.ControllerGetCapabilitiesRequest) error {
 	return nil
 }
 
 // NodeService RPCs
 
+type nodeServerValidator struct {
+	inner                csi.NodeServer
+	removingVolumeGroup  bool
+	supportedFilesystems map[string]string
+}
+
+func NodeServerValidator(inner csi.NodeServer, removingVolumeGroup bool, supportedFilesystems map[string]string) csi.NodeServer {
+	return &nodeServerValidator{inner, removingVolumeGroup, supportedFilesystems}
+}
+
+func (v *nodeServerValidator) NodePublishVolume(
+	ctx context.Context,
+	request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	if err := validateNodePublishVolumeRequest(request, v.removingVolumeGroup, v.supportedFilesystems); err != nil {
+		return nil, err
+	}
+	return v.inner.NodePublishVolume(ctx, request)
+}
+
 var ErrMissingTargetPath = status.Error(codes.InvalidArgument, "The target_path field must be specified.")
 var ErrMissingVolumeCapability = status.Error(codes.InvalidArgument, "The volume_capability field must be specified.")
 var ErrSpecifiedPublishInfo = status.Error(codes.InvalidArgument, "The publish_volume_info field must not be specified.")
 
-func (s *Server) validateNodePublishVolumeRequest(request *csi.NodePublishVolumeRequest) error {
-	if err := s.validateRemoving(); err != nil {
+func validateNodePublishVolumeRequest(request *csi.NodePublishVolumeRequest, removingVolumeGroup bool, supportedFilesystems map[string]string) error {
+	if err := validateRemoving(removingVolumeGroup); err != nil {
 		return err
 	}
 	volumeId := request.GetVolumeId()
@@ -224,15 +360,24 @@ func (s *Server) validateNodePublishVolumeRequest(request *csi.NodePublishVolume
 	} else {
 		const treatUnsupportedFsAsError = false
 		readonly := request.GetReadonly()
-		if err := s.validateVolumeCapability(volumeCapability, treatUnsupportedFsAsError, readonly); err != nil {
+		if err := validateVolumeCapability(volumeCapability, supportedFilesystems, treatUnsupportedFsAsError, readonly); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Server) validateNodeUnpublishVolumeRequest(request *csi.NodeUnpublishVolumeRequest) error {
-	if err := s.validateRemoving(); err != nil {
+func (v *nodeServerValidator) NodeUnpublishVolume(
+	ctx context.Context,
+	request *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	if err := validateNodeUnpublishVolumeRequest(request, v.removingVolumeGroup); err != nil {
+		return nil, err
+	}
+	return v.inner.NodeUnpublishVolume(ctx, request)
+}
+
+func validateNodeUnpublishVolumeRequest(request *csi.NodeUnpublishVolumeRequest, removingVolumeGroup bool) error {
+	if err := validateRemoving(removingVolumeGroup); err != nil {
 		return err
 	}
 	volumeId := request.GetVolumeId()
@@ -246,10 +391,33 @@ func (s *Server) validateNodeUnpublishVolumeRequest(request *csi.NodeUnpublishVo
 	return nil
 }
 
-func (s *Server) validateProbeRequest(request *csi.ProbeRequest) error {
+func (v *nodeServerValidator) NodeGetCapabilities(
+	ctx context.Context,
+	request *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	if err := validateNodeGetCapabilitiesRequest(request); err != nil {
+		return nil, err
+	}
+	return v.inner.NodeGetCapabilities(ctx, request)
+}
+
+func validateNodeGetCapabilitiesRequest(request *csi.NodeGetCapabilitiesRequest) error {
 	return nil
 }
 
-func (s *Server) validateNodeGetCapabilitiesRequest(request *csi.NodeGetCapabilitiesRequest) error {
-	return nil
+func (v *nodeServerValidator) NodeGetId(
+	ctx context.Context,
+	request *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
+	return v.NodeGetId(ctx, request)
+}
+
+func (v *nodeServerValidator) NodeStageVolume(
+	ctx context.Context,
+	request *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	return v.inner.NodeStageVolume(ctx, request)
+}
+
+func (v *nodeServerValidator) NodeUnstageVolume(
+	ctx context.Context,
+	request *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	return v.inner.NodeUnstageVolume(ctx, request)
 }

--- a/pkg/csilvm/validate.go
+++ b/pkg/csilvm/validate.go
@@ -135,7 +135,7 @@ var ErrUnsupportedFilesystem = status.Error(codes.FailedPrecondition, "The reque
 
 var ErrCapacityRangeUnspecified = status.Error(
 	codes.InvalidArgument,
-	"One of required_bytes or limit_bytes must"+
+	"One of required_bytes or limit_bytes must "+
 		"be specified if capacity_range is specified.")
 
 var ErrCapacityRangeInvalidSize = status.Error(

--- a/pkg/csilvm/validate.go
+++ b/pkg/csilvm/validate.go
@@ -61,7 +61,7 @@ func (v *identityServerValidator) Probe(
 	if err := validateProbeRequest(request); err != nil {
 		return nil, err
 	}
-	return v.Probe(ctx, request)
+	return v.inner.Probe(ctx, request)
 }
 
 func validateProbeRequest(request *csi.ProbeRequest) error {
@@ -306,7 +306,7 @@ func (v *controllerServerValidator) ControllerGetCapabilities(
 	if err := validateControllerGetCapabilitiesRequest(request); err != nil {
 		return nil, err
 	}
-	return v.ControllerGetCapabilities(ctx, request)
+	return v.inner.ControllerGetCapabilities(ctx, request)
 }
 
 func validateControllerGetCapabilitiesRequest(request *csi.ControllerGetCapabilitiesRequest) error {
@@ -407,7 +407,7 @@ func validateNodeGetCapabilitiesRequest(request *csi.NodeGetCapabilitiesRequest)
 func (v *nodeServerValidator) NodeGetId(
 	ctx context.Context,
 	request *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
-	return v.NodeGetId(ctx, request)
+	return v.inner.NodeGetId(ctx, request)
 }
 
 func (v *nodeServerValidator) NodeStageVolume(


### PR DESCRIPTION
This PR extracts the various request validation functions into separate structures. This way we use the type system to ensure that every RPC has a corresponding validation function.