### PR TITLE
Dockerfile: bump to LVM2.02.183 and add libaio dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,25 @@ FROM centos:7.3.1611
 
 RUN yum install -y gcc-4.8.5 gcc-c++-4.8.5 make git util-linux xfsprogs file
 
-ENV LVM2_DOWNLOAD_URL http://mirrors.kernel.org/sourceware/lvm2/LVM2.2.02.177.tgz
+RUN curl -O http://releases.pagure.org/libaio/libaio-0.3.110.tar.gz && \
+    curl http://releases.pagure.org/libaio/libaio-0.3.110.tar.gz.sha256sum | sha256sum --check && \
+    tar -xzvf libaio-0.3.110.tar.gz && \
+    cd libaio-0.3.110 && \
+    make install
 
-RUN curl -fsSL "$LVM2_DOWNLOAD_URL" -o LVM2.2.02.177.tgz && \
-      tar -xzvf LVM2.2.02.177.tgz && \
-      cd LVM2.2.02.177 && \
+ARG LVM_VERSION=LVM2.2.02.183
+
+ENV LVM2_DOWNLOAD_URL https://www.sourceware.org/pub/lvm2/$LVM_VERSION.tgz
+
+RUN curl -fsSL "$LVM2_DOWNLOAD_URL" -o $LVM_VERSION.tgz && \
+      tar -xzvf $LVM_VERSION.tgz && \
+      cd $LVM_VERSION && \
       ./configure && \
       make && \
       make install && \
       ldconfig && \
       cd .. && \
-      rm -f LVM2.2.02.177.tgz
+      rm -f $LVM_VERSION.tgz
 
 ENV GOLANG_VERSION 1.9.2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:7.3.1611
 
 RUN yum install -y gcc-4.8.5 gcc-c++-4.8.5 make git util-linux xfsprogs file
 
-RUN curl -O http://releases.pagure.org/libaio/libaio-0.3.110.tar.gz && \
-    curl http://releases.pagure.org/libaio/libaio-0.3.110.tar.gz.sha256sum | sha256sum --check && \
+RUN curl -O https://releases.pagure.org/libaio/libaio-0.3.110.tar.gz && \
+    curl https://releases.pagure.org/libaio/libaio-0.3.110.tar.gz.sha256sum | sha256sum --check && \
     tar -xzvf libaio-0.3.110.tar.gz && \
     cd libaio-0.3.110 && \
     make install

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,13 +40,6 @@ ansiColor('xterm') {
 
     stage("Build and Test") {
       withEnv(["DOCKER=yes","PACKAGE_SHA=${packageSHA}","PLUGIN_VERSION=${packageVersion}"]) {
-        // Install dependencies necessary to load raid-related kernel modules.
-        sh("sudo apt-get update")
-        sh("sudo apt-get install -y lvm2 kmod")
-	// Load the raid1 module on the host.
-        sh("sudo /sbin/modprobe raid1")
-	// Load the dm_raid module on the host.
-        sh("sudo /sbin/modprobe dm_raid")
         sh("make check")
         sh("make")
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The following command-line utilties must be present in the `PATH`:
 
 For RAID1 support the `raid1` and `dm_raid` kernel modules must be available.
 
-This plugin's tests are run in a centos 7.3.1611 container with lvm2-2.02.177 installed from source.
+This plugin's tests are run in a centos 7.3.1611 container with lvm2-2.02.183 installed from source.
 It should work with newer versions of lvm2 that are backwards-compatible in their command-line interface.
 It may work with older versions.
 

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -2295,7 +2295,10 @@ func TestSetup_NewVolumeGroup_BusyPhysicalVolume(t *testing.T) {
 		pv1name,
 	)
 	err = server.Setup()
-	if err.Error() != experr {
+	// TODO(gpaul): Contains instead of '==' as LVM2.02.180-183 has a bug
+	// where the error is printed twice.
+	// See https://jira.mesosphere.com/browse/DCOS_OSS-4650
+	if !strings.Contains(err.Error(), experr) {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This PR bumps the lvm2 utilities used for testing to LVM2.02.183.

Fixes https://jira.mesosphere.com/browse/DCOS_OSS-4643