### PR TITLE
pkg/csilvm: don't run pvck and vgck on Probe

### DIFF
--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -296,37 +296,21 @@ func (s *Server) Probe(
 	for _, pvname := range s.pvnames {
 		// Check that the LVM2 metadata written to the start of the PV parses.
 		log.Printf("Looking up LVM2 physical volume %v", pvname)
-		pv, err := lvm.LookupPhysicalVolume(pvname)
+		_, err := lvm.LookupPhysicalVolume(pvname)
 		if err != nil {
 			return nil, status.Errorf(
 				codes.FailedPrecondition,
 				"Cannot lookup physical volume %v: err=%v",
 				pvname, err)
 		}
-		log.Printf("Checking physical volume %v", pvname)
-		if err := pv.Check(); err != nil {
-			return nil, status.Errorf(
-				codes.FailedPrecondition,
-				"Physical volume %v failed check: err=%v",
-				pvname,
-				err)
-		}
 	}
 	log.Printf("Looking up volume group %v", s.vgname)
-	volumeGroup, err := lvm.LookupVolumeGroup(s.vgname)
+	_, err := lvm.LookupVolumeGroup(s.vgname)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.FailedPrecondition,
 			"Cannot find volume group %v",
 			s.vgname)
-	}
-	log.Printf("Checking volume group %v", s.vgname)
-	if err := volumeGroup.Check(); err != nil {
-		return nil, status.Errorf(
-			codes.FailedPrecondition,
-			"Volume group %v failed check: err=%v",
-			s.vgname,
-			err)
 	}
 	response := &csi.ProbeResponse{}
 	return response, nil


### PR DESCRIPTION
It appears that these commands scan the PVs and rebuilds / modifies the LVM2
metadata stored on the disk. The pvck and vgck commands expect user input.

We can run with --yes which answers yes to all prompts (which the man page
warns against with 'extreme caution').

We can run with --test which avoids updating metadata but still responds with
success. The man page warns that this may yield to confusing errors when
multi-stage operations expect that metadata was updated but it wasn't.

We can run with -qq which suppresses all output and answers 'no' to prompts.

None of these seem satisfying. We avoid running pvck and vgck until we
understand more about when to use it.

Fixes https://jira.mesosphere.com/browse/DCOS_OSS-4652