### PR TITLE
Serialize requests

### DIFF
--- a/cmd/csilvm/csilvm.go
+++ b/cmd/csilvm/csilvm.go
@@ -71,6 +71,7 @@ func main() {
 		grpc.UnaryInterceptor(
 			csilvm.ChainUnaryServer(
 				csilvm.LoggingInterceptor(),
+				csilvm.SerializingInterceptor(),
 			),
 		),
 	)

--- a/cmd/csilvm/csilvm.go
+++ b/cmd/csilvm/csilvm.go
@@ -70,8 +70,8 @@ func main() {
 	grpcOpts = append(grpcOpts,
 		grpc.UnaryInterceptor(
 			csilvm.ChainUnaryServer(
-				csilvm.LoggingInterceptor(),
 				csilvm.SerializingInterceptor(),
+				csilvm.LoggingInterceptor(),
 			),
 		),
 	)

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -1191,6 +1191,8 @@ func volumeOptsFromParameters(in map[string]string) (opts []lvm.CreateLogicalVol
 
 // Serialize all requests. This avoids issues observed when deleting 80 logical
 // volumes in parallel where calls to `lvs` appear to hang.
+//
+// See https://jira.mesosphere.com/browse/DCOS_OSS-4642
 func SerializingInterceptor() grpc.UnaryServerInterceptor {
 	var lk sync.Mutex
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mesosphere/csilvm/pkg/lvm"
 	"github.com/mesosphere/csilvm/pkg/version"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )


### PR DESCRIPTION
This PR works around issues observed in LVM2.02.177 where there appears to be some unexpected races between `lvs` and `lvremove`. See the jira issue for more details.

Fixes https://jira.mesosphere.com/browse/DCOS_OSS-4642