### PR TITLE
[[--hold--]] Dedup requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
+# vim swap files
+*.swp
+
 /csilvm

--- a/cmd/csilvm/csilvm.go
+++ b/cmd/csilvm/csilvm.go
@@ -43,6 +43,7 @@ func main() {
 	socketFileF := flag.String("unix-addr", "", "The path to the listening unix socket file")
 	socketFileEnvF := flag.String("unix-addr-env", "", "An optional environment variable from which to read the unix-addr")
 	removeF := flag.Bool("remove-volume-group", false, "If set, the volume group will be removed when ProbeNode is called.")
+	exclusiveF := flag.Bool("exclusive-rpcs", false, "If set, all RPCs are executed in a non-overlapping manner.")
 	var tagsF stringsFlag
 	flag.Var(&tagsF, "tag", "Value to tag the volume group with (can be given multiple times)")
 	flag.Parse()
@@ -77,7 +78,7 @@ func main() {
 		grpc.UnaryInterceptor(
 			csilvm.ChainUnaryServer(
 				csilvm.RequestLimitInterceptor(*requestLimitF),
-				csilvm.SerializingInterceptor(),
+				csilvm.SerializingInterceptor(*exclusiveF),
 				csilvm.LoggingInterceptor(),
 			),
 		),

--- a/pkg/csilvm/arbiter.go
+++ b/pkg/csilvm/arbiter.go
@@ -1,0 +1,398 @@
+package csilvm
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"sync"
+
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/mesosphere/csilvm/pkg/singleflight"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ = csi.IdentityServer(&identityArbiter{}) // sanity check
+
+type RPCCounters struct {
+	IssuedCall func() int64 // callback useful for testing
+	SharedCall func() int64 // callback useful for testing
+}
+
+type GenericArbiter struct {
+	RPCCounters
+	singleflight.Group
+}
+
+func (g *GenericArbiter) Do(ctx context.Context, key string, nonce []byte, fn func() (interface{}, error)) (interface{}, error) {
+	ch, ok := g.DoChan(key, nonce, fn)
+	if !ok {
+		return nil, status.Error(codes.Aborted, nonceMismatch)
+	}
+	if g.IssuedCall != nil {
+		g.IssuedCall()
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Shared && g.SharedCall != nil {
+			g.SharedCall()
+		}
+		return res.Val, res.Err
+	}
+}
+
+type identityArbiter struct {
+	GenericArbiter
+	csi.IdentityServer
+}
+
+type ArbiterOption func(*GenericArbiter)
+
+func IdentityArbiter(server csi.IdentityServer, opt ...ArbiterOption) csi.IdentityServer {
+	var generic GenericArbiter
+	for _, f := range opt {
+		f(&generic)
+	}
+	return &identityArbiter{
+		GenericArbiter: generic,
+		IdentityServer: server,
+	}
+}
+
+// Probe can take some time to execute: merge all in-flight Probe requests.
+func (v *identityArbiter) Probe(
+	ctx context.Context,
+	request *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+
+	const key = "prb" // all probe requests are identical, merge all concurrent req's
+	worker := func() (interface{}, error) { return v.IdentityServer.Probe(ctx, request) }
+	res, err := v.Do(ctx, key, nil, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.ProbeResponse), nil
+}
+
+var _ = csi.ControllerServer(&controllerArbiter{}) // sanity check
+
+type controllerArbiter struct {
+	GenericArbiter
+	csi.ControllerServer
+	removeLock sync.RWMutex // removeLock is write-locked for remove ops and read-locked for non-remove ops that could conflict w/ remove.
+}
+
+// ControllerArbiter decorates a ControllerServer and also returns a Locker that can be
+// used to coordinate operations that should not overlap w/ specific controller ops.
+func ControllerArbiter(server csi.ControllerServer, opt ...ArbiterOption) (csi.ControllerServer, sync.Locker) {
+	var generic GenericArbiter
+	for _, f := range opt {
+		f(&generic)
+	}
+	arb := &controllerArbiter{
+		GenericArbiter:   generic,
+		ControllerServer: server,
+	}
+	return arb, arb.removeLock.RLocker()
+}
+
+const nonceMismatch = "A competing operation, with conflicting parameters, is already in progress."
+
+// CreateVolume merges idempotent requests; waits for any pending RemoveVolume ops to complete.
+func (v *controllerArbiter) CreateVolume(
+	ctx context.Context,
+	request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.removeLock.RLock()
+		defer v.removeLock.RUnlock()
+		return v.ControllerServer.CreateVolume(ctx, request)
+	}
+
+	type Nonce struct { // json encoding has predictable key order
+		Name             string            `json:"nm,omitempty"`
+		MountFS          []string          `json:"fs,omitempty"`
+		Parameters       map[string]string `json:"p,omitempty"`
+		RequiredCapacity int64             `json:"cr,omitempty"`
+		LimitCapacity    int64             `json:"cl,omitempty"`
+	}
+	buf, err := json.Marshal(&Nonce{
+		Name:             request.Name,
+		MountFS:          squashCaps(request.GetVolumeCapabilities()...),
+		Parameters:       request.Parameters,
+		RequiredCapacity: request.GetCapacityRange().GetRequiredBytes(),
+		LimitCapacity:    request.GetCapacityRange().GetLimitBytes(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	const ns = "new/"
+	res, err := v.Do(ctx, ns+request.Name, buf, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.CreateVolumeResponse), nil
+}
+
+func (v *controllerArbiter) DeleteVolume(
+	ctx context.Context,
+	request *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.removeLock.Lock()
+		defer v.removeLock.Unlock()
+		return v.ControllerServer.DeleteVolume(ctx, request)
+	}
+
+	const ns = "del/"
+	res, err := v.Do(ctx, ns+request.VolumeId, nil, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.DeleteVolumeResponse), nil
+}
+
+func (v *controllerArbiter) ControllerPublishVolume(
+	ctx context.Context,
+	request *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.removeLock.RLock()
+		defer v.removeLock.RUnlock()
+		return v.ControllerServer.ControllerPublishVolume(ctx, request)
+	}
+	type Nonce struct { // json encoding has predictable key order
+		VolID    string   `json:"id,omitempty"`
+		NodeID   string   `json:"ni,omitempty"`
+		MountFS  []string `json:"fs,omitempty"`
+		ReadOnly bool     `json:"ro,omitempty"`
+	}
+	buf, err := json.Marshal(&Nonce{
+		VolID:    request.VolumeId,
+		NodeID:   request.NodeId,
+		MountFS:  squashCaps(request.VolumeCapability),
+		ReadOnly: request.Readonly,
+	})
+	if err != nil {
+		return nil, err
+	}
+	const ns = "pub/"
+	res, err := v.Do(ctx, ns+request.VolumeId, buf, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.ControllerPublishVolumeResponse), nil
+}
+
+func (v *controllerArbiter) ControllerUnpublishVolume(
+	ctx context.Context,
+	request *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.removeLock.RLock()
+		defer v.removeLock.RUnlock()
+		return v.ControllerServer.ControllerUnpublishVolume(ctx, request)
+	}
+	type Nonce struct { // json encoding has predictable key order
+		VolID  string `json:"id,omitempty"`
+		NodeID string `json:"ni,omitempty"`
+	}
+	buf, err := json.Marshal(&Nonce{
+		VolID:  request.VolumeId,
+		NodeID: request.NodeId,
+	})
+	if err != nil {
+		return nil, err
+	}
+	const ns = "unpub/"
+	res, err := v.Do(ctx, ns+request.VolumeId, buf, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.ControllerUnpublishVolumeResponse), nil
+}
+
+func (v *controllerArbiter) ValidateVolumeCapabilities(
+	ctx context.Context,
+	request *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.removeLock.RLock()
+		defer v.removeLock.RUnlock()
+		return v.ControllerServer.ValidateVolumeCapabilities(ctx, request)
+	}
+	type Nonce struct { // json encoding has predictable key order
+		VolID   string   `json:"id,omitempty"`
+		MountFS []string `json:"fs,omitempty"`
+	}
+	buf, err := json.Marshal(&Nonce{
+		VolID:   request.VolumeId,
+		MountFS: squashCaps(request.GetVolumeCapabilities()...),
+	})
+	if err != nil {
+		return nil, err
+	}
+	const ns = "validate/"
+	res, err := v.Do(ctx, ns+request.VolumeId, buf, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.ValidateVolumeCapabilitiesResponse), nil
+}
+
+func (v *controllerArbiter) ListVolumes(
+	ctx context.Context,
+	request *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.removeLock.RLock()
+		defer v.removeLock.RUnlock()
+		return v.ControllerServer.ListVolumes(ctx, request)
+	}
+	const ns = "list/"
+	res, err := v.Do(ctx, ns+request.StartingToken, nil, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.ListVolumesResponse), nil
+}
+
+func squashCaps(caps ...*csi.VolumeCapability) (fs []string) {
+	for _, vc := range caps {
+		if m := vc.GetMount(); m != nil {
+			if m.FsType != "" {
+				fs = append(fs, m.FsType)
+			}
+		}
+		if b := vc.GetBlock(); b != nil {
+			// we need a placeholder...
+			fs = append(fs, "**block")
+		}
+		fs = append(fs, vc.GetAccessMode().GetMode().String())
+	}
+	sort.Strings(fs)
+	return
+}
+
+func (v *controllerArbiter) GetCapacity(
+	ctx context.Context,
+	request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+
+	type Key struct { // json encoding has predictable key order
+		MountFS    []string          `json:"fs,omitempty"`
+		Parameters map[string]string `json:"p,omitempty"`
+	}
+	key := Key{
+		MountFS:    squashCaps(request.GetVolumeCapabilities()...),
+		Parameters: request.Parameters,
+	}
+	buf, err := json.Marshal(&key)
+	if err != nil {
+		return nil, err
+	}
+
+	worker := func() (interface{}, error) {
+		v.removeLock.RLock()
+		defer v.removeLock.RUnlock()
+		return v.ControllerServer.GetCapacity(ctx, request)
+	}
+	const ns = "cap/"
+	res, err := v.Do(ctx, ns+string(buf), nil, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.GetCapacityResponse), nil
+}
+
+var _ = csi.NodeServer(&nodeArbiter{}) // sanity check
+
+type nodeArbiter struct {
+	GenericArbiter
+	csi.NodeServer
+	g    *singleflight.Group
+	lock sync.Locker
+}
+
+func NodeArbiter(server csi.NodeServer, lock sync.Locker, opt ...ArbiterOption) csi.NodeServer {
+	var generic GenericArbiter
+	for _, f := range opt {
+		f(&generic)
+	}
+	return &nodeArbiter{
+		GenericArbiter: generic,
+		NodeServer:     server,
+		g:              new(singleflight.Group),
+		lock:           lock,
+	}
+}
+func (v *nodeArbiter) NodePublishVolume(
+	ctx context.Context,
+	request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.lock.Lock()
+		defer v.lock.Unlock()
+		return v.NodeServer.NodePublishVolume(ctx, request)
+	}
+	const ns = "pub/"
+	type Key struct {
+		VolumeID          string `json:"id,omitempty"`
+		StagingTargetPath string `json:"sp,omitempty"`
+		TargetPath        string `json:"tp,omitempty"`
+	}
+	buf, err := json.Marshal(&Key{
+		VolumeID:          request.VolumeId,
+		StagingTargetPath: request.StagingTargetPath,
+		TargetPath:        request.TargetPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+	key := ns + string(buf)
+	type Nonce struct {
+		MountFS  []string `json:"fs,omitempty"`
+		ReadOnly bool     `json:"ro,omitempty"`
+	}
+	nb, err := json.Marshal(&Nonce{
+		MountFS:  squashCaps(request.VolumeCapability),
+		ReadOnly: request.Readonly,
+	})
+	if err != nil {
+		return nil, err
+	}
+	res, err := v.Do(ctx, key, nb, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.NodePublishVolumeResponse), nil
+}
+
+func (v *nodeArbiter) NodeUnpublishVolume(
+	ctx context.Context,
+	request *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+
+	worker := func() (interface{}, error) {
+		v.lock.Lock()
+		defer v.lock.Unlock()
+		return v.NodeServer.NodeUnpublishVolume(ctx, request)
+	}
+	const ns = "unpub/"
+	type Key struct {
+		VolumeID   string `json:"id,omitempty"`
+		TargetPath string `json:"tp,omitempty"`
+	}
+	buf, err := json.Marshal(&Key{
+		VolumeID:   request.VolumeId,
+		TargetPath: request.TargetPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+	key := ns + string(buf)
+	res, err := v.Do(ctx, key, nil, worker)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*csi.NodeUnpublishVolumeResponse), nil
+}

--- a/pkg/csilvm/arbiter_test.go
+++ b/pkg/csilvm/arbiter_test.go
@@ -479,3 +479,31 @@ func testNodeArbiter(t *testing.T, conf func(*fakeNodeServer, func() (interface{
 	default:
 	}
 }
+
+func TestCtxValues(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(100*time.Second))
+	ctx = context.WithValue(ctx, "key", "value")
+	cancel()
+
+	ctx2 := ctxValues(ctx)
+	select {
+	case <-ctx2.Done():
+		t.Fatal("ctx2 unexpectedly completed")
+	default:
+	}
+
+	if d, ok := ctx2.Deadline(); ok {
+		t.Fatalf("ctx2 has an unexpected deadline: %v", d)
+	}
+
+	v := ctx2.Value("key")
+	if v.(string) != "value" {
+		t.Fatalf("unexpected value %v", v)
+	}
+
+	ctx2 = context.WithValue(ctx2, "key", "value2")
+	v = ctx2.Value("key")
+	if v.(string) != "value2" {
+		t.Fatalf("unexpected value %v", v)
+	}
+}

--- a/pkg/csilvm/arbiter_test.go
+++ b/pkg/csilvm/arbiter_test.go
@@ -1,0 +1,481 @@
+package csilvm
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+const patience = 5 * time.Second // XXX bump this for CI
+
+type fakeIdentityServer struct {
+	csi.IdentityServer
+	probe func(context.Context, *csi.ProbeRequest) (*csi.ProbeResponse, error)
+}
+
+func (f *fakeIdentityServer) Probe(
+	ctx context.Context,
+	request *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	return f.probe(ctx, request)
+}
+
+var tooManyCalls = errors.New("rpc called too many times")
+
+func calledAtMostOnce(t *testing.T) (func(), <-chan error) {
+	var calls int32
+	errors := make(chan error, 1)
+	return func() {
+		latest := atomic.AddInt32(&calls, 1)
+		if latest > 1 {
+			// should only be called once
+			t.Log("called too many times")
+			select {
+			case errors <- tooManyCalls:
+			default:
+			}
+		}
+	}, errors
+}
+
+type result struct {
+	response interface{}
+	err      error
+}
+
+func newResult(response interface{}, err error) result {
+	if err != nil {
+		return result{err: err}
+	}
+	return result{response: response}
+}
+
+func newCounter() (get, inc func() int64) {
+	var val int64
+	return func() int64 { return atomic.LoadInt64(&val) },
+		func() int64 { return atomic.AddInt64(&val, 1) }
+}
+
+func arbiterCounters() (_ ArbiterOption, issued func() int64, shared func() int64) {
+	getIssued, incIssued := newCounter()
+	getShared, incShared := newCounter()
+	return func(g *GenericArbiter) {
+		g.IssuedCall = incIssued
+		g.SharedCall = incShared
+	}, getIssued, getShared
+}
+
+func waitForCounter(t *testing.T, val int64, counter func() int64, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	var found bool
+	var last int64
+	for {
+		last = counter()
+		if last == val {
+			found = true
+			break
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	if !found {
+		t.Errorf("timed out waiting for counter (%d) to match expectations (%d)", last, val)
+	}
+}
+
+var errFailedRPC = errors.New("someRPCError")
+
+func TestIdentityArbiterProbe(t *testing.T) {
+	rpcComplete := make(chan struct{})
+	checkCalledOnce, errors := calledAtMostOnce(t)
+	const workers = 5
+	fakeWrapped := &fakeIdentityServer{
+		probe: func(context.Context, *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+			checkCalledOnce()
+			<-rpcComplete
+			return nil, errFailedRPC
+		},
+	}
+	opt, issuedCalls, sharedCalls := arbiterCounters()
+	arb := IdentityArbiter(fakeWrapped, opt) // this is the arbiter we're testing
+	var (
+		m       sync.Mutex
+		g       sync.WaitGroup
+		results []result
+	)
+	g.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer g.Done()
+			resp, err := arb.Probe(context.Background(), nil)
+			m.Lock()
+			defer m.Unlock()
+			results = append(results, newResult(resp, err))
+		}()
+	}
+
+	// wait for issued calls == number of workers
+	waitForCounter(t, workers, issuedCalls, patience)
+	close(rpcComplete)
+	g.Wait()
+
+	// check sharedCalls
+	waitForCounter(t, workers, sharedCalls, 0)
+
+	// check for expected errors
+	if len(results) != workers {
+		t.Fatalf("unexpected number of results: %v", results)
+	}
+	for _, r := range results {
+		if r.err == errFailedRPC {
+			continue
+		}
+		t.Fatalf("unexpected error: %v", r.err)
+	}
+
+	// check for unexpected errors
+	select {
+	case err := <-errors:
+		t.Fatal(err)
+	default:
+	}
+}
+
+type fakeControllerServer struct {
+	csi.ControllerServer
+	createVolume               func(context.Context, *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error)
+	deleteVolume               func(context.Context, *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error)
+	controllerPublishVolume    func(context.Context, *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error)
+	controllerUnpublishVolume  func(context.Context, *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error)
+	validateVolumeCapabilities func(context.Context, *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error)
+	listVolumes                func(context.Context, *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error)
+	getCapacity                func(context.Context, *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error)
+}
+
+func (f *fakeControllerServer) CreateVolume(
+	ctx context.Context,
+	request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	return f.createVolume(ctx, request)
+}
+
+func (f *fakeControllerServer) DeleteVolume(
+	ctx context.Context,
+	request *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	return f.deleteVolume(ctx, request)
+}
+
+func (f *fakeControllerServer) ControllerPublishVolume(
+	ctx context.Context,
+	request *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	return f.controllerPublishVolume(ctx, request)
+}
+
+func (f *fakeControllerServer) ControllerUnpublishVolume(
+	ctx context.Context,
+	request *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	return f.controllerUnpublishVolume(ctx, request)
+}
+
+func (f *fakeControllerServer) ValidateVolumeCapabilities(
+	ctx context.Context,
+	request *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	return f.validateVolumeCapabilities(ctx, request)
+}
+
+func (f *fakeControllerServer) ListVolumes(
+	ctx context.Context,
+	request *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	return f.listVolumes(ctx, request)
+}
+
+func (f *fakeControllerServer) GetCapacity(
+	ctx context.Context,
+	request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+	return f.getCapacity(ctx, request)
+}
+
+func TestControllerArbiter(t *testing.T) {
+	for ti, tc := range []struct {
+		conf func(*fakeControllerServer, func() (interface{}, error))
+		exec func(csi.ControllerServer) (interface{}, error)
+	}{
+		{
+			conf: func(f *fakeControllerServer, action func() (interface{}, error)) {
+				f.createVolume = func(context.Context, *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.CreateVolumeResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.ControllerServer) (interface{}, error) {
+				return arb.CreateVolume(context.Background(), &csi.CreateVolumeRequest{})
+			},
+		},
+		{
+			conf: func(f *fakeControllerServer, action func() (interface{}, error)) {
+				f.deleteVolume = func(context.Context, *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.DeleteVolumeResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.ControllerServer) (interface{}, error) {
+				return arb.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{})
+			},
+		},
+		{
+			conf: func(f *fakeControllerServer, action func() (interface{}, error)) {
+				f.controllerPublishVolume = func(context.Context, *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.ControllerPublishVolumeResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.ControllerServer) (interface{}, error) {
+				return arb.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{})
+			},
+		},
+		{
+			conf: func(f *fakeControllerServer, action func() (interface{}, error)) {
+				f.controllerUnpublishVolume = func(context.Context, *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.ControllerUnpublishVolumeResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.ControllerServer) (interface{}, error) {
+				return arb.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{})
+			},
+		},
+		{
+			conf: func(f *fakeControllerServer, action func() (interface{}, error)) {
+				f.validateVolumeCapabilities = func(context.Context, *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.ValidateVolumeCapabilitiesResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.ControllerServer) (interface{}, error) {
+				return arb.ValidateVolumeCapabilities(context.Background(), &csi.ValidateVolumeCapabilitiesRequest{})
+			},
+		},
+		{
+			conf: func(f *fakeControllerServer, action func() (interface{}, error)) {
+				f.listVolumes = func(context.Context, *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.ListVolumesResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.ControllerServer) (interface{}, error) {
+				return arb.ListVolumes(context.Background(), &csi.ListVolumesRequest{})
+			},
+		},
+		{
+			conf: func(f *fakeControllerServer, action func() (interface{}, error)) {
+				f.getCapacity = func(context.Context, *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.GetCapacityResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.ControllerServer) (interface{}, error) {
+				return arb.GetCapacity(context.Background(), &csi.GetCapacityRequest{})
+			},
+		},
+	} {
+		t.Run(strconv.Itoa(ti), func(t *testing.T) {
+			testControllerArbiter(t, tc.conf, tc.exec)
+		})
+	}
+}
+
+func testControllerArbiter(t *testing.T, conf func(*fakeControllerServer, func() (interface{}, error)), exec func(csi.ControllerServer) (interface{}, error)) {
+	rpcComplete := make(chan struct{})
+	checkCalledOnce, errors := calledAtMostOnce(t)
+	const workers = 5
+	var fakeWrapped fakeControllerServer
+	conf(&fakeWrapped, func() (interface{}, error) {
+		checkCalledOnce()
+		<-rpcComplete
+		return nil, errFailedRPC
+	})
+	opt, issuedCalls, sharedCalls := arbiterCounters()
+	arb, _ := ControllerArbiter(&fakeWrapped, opt) // this is the arbiter we're testing
+	var (
+		m       sync.Mutex
+		g       sync.WaitGroup
+		results []result
+	)
+	g.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer g.Done()
+			resp, err := exec(arb)
+			m.Lock()
+			defer m.Unlock()
+			results = append(results, newResult(resp, err))
+		}()
+	}
+
+	// wait for issued calls == number of workers
+	waitForCounter(t, workers, issuedCalls, patience)
+	close(rpcComplete)
+	g.Wait()
+
+	// check sharedCalls
+	waitForCounter(t, workers, sharedCalls, 0)
+
+	// check for expected errors
+	if len(results) != workers {
+		t.Fatalf("unexpected number of results: %v", results)
+	}
+	for _, r := range results {
+		if r.err == errFailedRPC {
+			continue
+		}
+		t.Fatalf("unexpected error: %v", r.err)
+	}
+
+	// check for unexpected errors
+	select {
+	case err := <-errors:
+		t.Fatal(err)
+	default:
+	}
+}
+
+type fakeNodeServer struct {
+	csi.NodeServer
+	nodePublishVolume   func(context.Context, *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
+	nodeUnpublishVolume func(context.Context, *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error)
+}
+
+func (f *fakeNodeServer) NodePublishVolume(
+	ctx context.Context,
+	request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	return f.nodePublishVolume(ctx, request)
+}
+
+func (f *fakeNodeServer) NodeUnpublishVolume(
+	ctx context.Context,
+	request *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	return f.nodeUnpublishVolume(ctx, request)
+}
+
+func TestNodeArbiter(t *testing.T) {
+	for ti, tc := range []struct {
+		conf func(*fakeNodeServer, func() (interface{}, error))
+		exec func(csi.NodeServer) (interface{}, error)
+	}{
+		{
+			conf: func(f *fakeNodeServer, action func() (interface{}, error)) {
+				f.nodePublishVolume = func(context.Context, *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.NodePublishVolumeResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.NodeServer) (interface{}, error) {
+				return arb.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{})
+			},
+		},
+		{
+			conf: func(f *fakeNodeServer, action func() (interface{}, error)) {
+				f.nodeUnpublishVolume = func(context.Context, *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+					v, err := action()
+					if v != nil {
+						return v.(*csi.NodeUnpublishVolumeResponse), err
+					}
+					return nil, err
+				}
+			},
+			exec: func(arb csi.NodeServer) (interface{}, error) {
+				return arb.NodeUnpublishVolume(context.Background(), &csi.NodeUnpublishVolumeRequest{})
+			},
+		},
+	} {
+		t.Run(strconv.Itoa(ti), func(t *testing.T) {
+			testNodeArbiter(t, tc.conf, tc.exec)
+		})
+	}
+}
+
+func testNodeArbiter(t *testing.T, conf func(*fakeNodeServer, func() (interface{}, error)), exec func(csi.NodeServer) (interface{}, error)) {
+	rpcComplete := make(chan struct{})
+	checkCalledOnce, errors := calledAtMostOnce(t)
+	const workers = 5
+	var fakeWrapped fakeNodeServer
+	conf(&fakeWrapped, func() (interface{}, error) {
+		checkCalledOnce()
+		<-rpcComplete
+		return nil, errFailedRPC
+	})
+	opt, issuedCalls, sharedCalls := arbiterCounters()
+	arb := NodeArbiter(&fakeWrapped, new(sync.Mutex), opt) // this is the arbiter we're testing
+	var (
+		m       sync.Mutex
+		g       sync.WaitGroup
+		results []result
+	)
+	g.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer g.Done()
+			resp, err := exec(arb)
+			m.Lock()
+			defer m.Unlock()
+			results = append(results, newResult(resp, err))
+		}()
+	}
+
+	// wait for issued calls == number of workers
+	waitForCounter(t, workers, issuedCalls, patience)
+	close(rpcComplete)
+	g.Wait()
+
+	// check sharedCalls
+	waitForCounter(t, workers, sharedCalls, 0)
+
+	// check for expected errors
+	if len(results) != workers {
+		t.Fatalf("unexpected number of results: %v", results)
+	}
+	for _, r := range results {
+		if r.err == errFailedRPC {
+			continue
+		}
+		t.Fatalf("unexpected error: %v", r.err)
+	}
+
+	// check for unexpected errors
+	select {
+	case err := <-errors:
+		t.Fatal(err)
+	default:
+	}
+}

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -1195,11 +1195,13 @@ func volumeOptsFromParameters(in map[string]string) (opts []lvm.CreateLogicalVol
 // volumes in parallel where calls to `lvs` appear to hang.
 //
 // See https://jira.mesosphere.com/browse/DCOS_OSS-4642
-func SerializingInterceptor() grpc.UnaryServerInterceptor {
+func SerializingInterceptor(enabled bool) grpc.UnaryServerInterceptor {
 	var lk sync.Mutex
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		lk.Lock()
-		defer lk.Unlock()
+		if enabled {
+			lk.Lock()
+			defer lk.Unlock()
+		}
 		return handler(ctx, req)
 	}
 }

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -1,0 +1,92 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight
+
+import (
+	"bytes"
+	"sync"
+)
+
+// call is an in-flight or completed singleflight.DoChan call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+
+	// Read and written with the singleflight mutex held.
+	nonce []byte
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of DoChan, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// DoChan executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// Returns a channel that will receive the results when they are ready.
+// The Result value shared indicates whether v was given to multiple callers.
+// Returns false if the specified nonce doesn't match the nonce of a call already in progress.
+func (g *Group) DoChan(key string, nonce []byte, fn func() (interface{}, error)) (<-chan Result, bool) {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		if x, y := len(c.nonce), len(nonce); x != y || bytes.Compare(c.nonce, nonce) != 0 {
+			g.mu.Unlock()
+			return nil, false
+		}
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch, true
+	}
+	c := &call{chans: []chan<- Result{ch}, nonce: nonce}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch, true
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	delete(g.m, key)
+	for _, ch := range c.chans {
+		ch <- Result{c.val, c.err, c.dups > 0}
+	}
+	g.mu.Unlock()
+}


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-4685

Evolves #82, see https://jira.mesosphere.com/browse/DCOS_OSS-4642.

Notable:
- `request-limit` applies before de-duping: it limits the number of in-flight network requests are allowed (even if they're idempotent requests). client-canceled requests are automatically dropped from the queue to make room for other requests. this work was implemented as part of a prior PR but it's worth calling out for clarity w/ respect to this set of changes.
- `exclusive-rpcs` exposes a previously hard-coded semantic and flips the enforced default value to "don't run every RPC in a mutually exclusive way".
- `*Arbiter` implementations were added to `pkg/csilvm` to govern (a) concurrency, and (b) request coalescing on a per-RPC basis. The goal is that `DeleteVolume` operations are exclusive and may not overlap any other RPC that touches LVM (including other `DeleteVolume` operations). Exclusivity is applied to coalesced requests, such that idempotent `DeleteVolume` requests that arrive in close proximity can share the same lock.
- Cancellation of a client RPC via `context.Context` is ignored by the core/underlying `*Server` that's executing the actual LVM operations: since requests are now coalesced we don't want cancellation of a singular request to impact the others it was merged with. Client context cancellation will abort the network request and leave an ongoing LVM operation intact.

TODO:
- [x] resolve the `*Arbiter` TODOs regarding "key" calculation for coalescing idempotent requests.
- [x] unit tests for all the new code.
- [ ] consider further limiting the max number of concurrent sub-processes. each sub-process consumes valuable memory and we should probably aim to be a bit more conservative.
- [ ] consider rate-limiting the number of sub-processes launched per second, although the memory footprint of the csilvm plugin is fairly low so we might consider deferring the work for a per-second limit.