### PR TITLE
csilvm: vol attrs use b64 raw URL encoding vs std

### DIFF
--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -1051,7 +1051,7 @@ func TestListVolumes_TwoVolumes(t *testing.T) {
 		if !ok {
 			t.Fatalf("volume attributes missing tags")
 		}
-		buf, err := base64.StdEncoding.DecodeString(etags)
+		buf, err := base64.RawURLEncoding.DecodeString(etags)
 		if err != nil {
 			t.Fatal("failed to decode tags:", err)
 		}

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -396,7 +396,7 @@ func (s *Server) volumeAttributes(lv *lvm.LogicalVolume) (map[string]string, err
 		return nil, err
 	}
 	return map[string]string{
-		attrTags: base64.StdEncoding.EncodeToString(buf),
+		attrTags: base64.RawURLEncoding.EncodeToString(buf),
 	}, nil
 }
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49804

TL;DR: eliminate special characters and padding from attribute values. simplifies ops jobs, like scanning logs.