### PR TITLE
Use shorter, randomly generated volume ID names

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,12 @@ Instead, it relies on LVM2 to lock around operations that are not reentrant.
 
 The volume group name is specified at startup through the `-volume-group` argument.
 
-Logical volumes names are chosen from randomly-generated, base36-encoded numbers.
-The CO-specified volume name is captured in a LV tag: `<prefix>_<fn(CO-specified-name)>`, where `<prefix>` is either of:
+Logical volume names are derived from randomly generated, base36-encoded numbers and are prefixed with `csilv`, for example: `csilv9T8s7d3`.
 
-* `VN.` - used when the CO-specified name contains *only* characters safe for LVM tags; `fn` is the identity func here.
-* `VN+` - used when the CO-specified name contains 1 or more characters unsafe for LVM tags; `fn` is base64-rawurl-encoding here.
+The CO-specified volume name is captured in a LV tag conforming to one of the following formats:
+
+* `VN.<CO-specified-name>`, if the CO-specified name contains *only* characters safe for LVM tags (`A-Z a-z 0-9 + _ . -`).
+* `VN+<base64-rawurlencode(CO-specified-name)>`, otherwise. Encoding is performed without padding.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -223,12 +223,18 @@ Instead, it relies on LVM2 to lock around operations that are not reentrant.
 
 #### Logical volume naming
 
-The volume group name is specified at startup through the
-`-volume-group` argument.
+The volume group name is specified at startup through the `-volume-group` argument.
 
-Logical volumes are named according to the following pattern
-`<volume-group-name>_<logical-volume-name>`.
+Logical volumes names are chosen from randomly-generated, base36-encoded numbers.
+The CO-specified volume name is captured in a LV tag: `<prefix>_<fn(CO-specified-name)>`, where `<prefix>` is either of:
 
+* `VN.` - used when the CO-specified name contains *only* characters safe for LVM tags; `fn` is the identity func here.
+* `VN+` - used when the CO-specified name contains 1 or more characters unsafe for LVM tags; `fn` is base64-rawurl-encoding here.
+
+Examples:
+
+* If the CO-specified volume name is `test-volume`, then the generated LV tag is `VN.test-volume`.
+* If the CO-specified volume name is `hello volume`, then the generated LV tag is `VN+aGVsbG8gdm9sdW1l`.
 
 #### SINGLE_NODE_READER_ONLY
 

--- a/cmd/csilvm/csilvm.go
+++ b/cmd/csilvm/csilvm.go
@@ -4,9 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc"
 
@@ -33,6 +35,8 @@ func (f *stringsFlag) Set(tag string) error {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	// Configure flags
 	requestLimitF := flag.Int("request-limit", defaultRequestLimit, "Limits backlog of pending requests.")
 	vgnameF := flag.String("volume-group", "", "The name of the volume group to manage")

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -438,7 +438,8 @@ func (s *Server) CreateVolume(
 	// Generate a random volume name and ensure that it doesn't already exist.
 	var volumeID string
 	for i := 0; i < 10 && volumeID == ""; i++ {
-		tryID := strconv.FormatUint(rand.Uint64(), 36)
+		// prefix a random number with "v" to avoid stomping on reserved names.
+		tryID := "v" + strconv.FormatUint(rand.Uint64(), 36)
 		log.Printf("Attempting to allocate id=%v for requested volume %q", tryID, request.GetName())
 		if _, err := s.volumeGroup.LookupLogicalVolume(tryID); err == nil {
 			log.Printf("Volume id %s already exists, trying again..", tryID)

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -437,9 +437,10 @@ func (s *Server) CreateVolume(
 	}
 	// Generate a random volume name and ensure that it doesn't already exist.
 	var volumeID string
+	const lvPrefix = "csilv"
 	for i := 0; i < 10 && volumeID == ""; i++ {
-		// prefix a random number with "v" to avoid stomping on reserved names.
-		tryID := "v" + strconv.FormatUint(rand.Uint64(), 36)
+		// prefix a random number to avoid stomping on reserved names.
+		tryID := lvPrefix + strconv.FormatUint(rand.Uint64(), 36)
 		log.Printf("Attempting to allocate id=%v for requested volume %q", tryID, request.GetName())
 		if _, err := s.volumeGroup.LookupLogicalVolume(tryID); err == nil {
 			log.Printf("Volume id %s already exists, trying again..", tryID)

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -403,12 +404,18 @@ func (s *Server) volumeAttributes(lv *lvm.LogicalVolume) (map[string]string, err
 func (s *Server) CreateVolume(
 	ctx context.Context,
 	request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+
+	// Record the original volume name as a tag.
+	encodedName := s.volumeNameToTag(request.GetName())
+	tags := make([]string, len(s.tags), len(s.tags)+1)
+	copy(tags, s.tags)
+	tags = append(tags, encodedName)
+
 	// Check whether a logical volume with the given name already
 	// exists in this volume group.
-	volumeId := s.volumeNameToId(request.GetName())
-	log.Printf("Determining whether volume with id=%v already exists", volumeId)
-	if lv, err := s.volumeGroup.LookupLogicalVolume(volumeId); err == nil {
-		log.Printf("Volume %s already exists.", request.GetName())
+	log.Printf("Determining whether volume %q with encoded name %v already exists", request.GetName(), encodedName)
+	if lv, err := s.volumeGroup.FindLogicalVolume(lvm.LVMatchTag(encodedName)); err == nil {
+		log.Printf("Volume %s already exists.", encodedName)
 		// The volume already exists. Determine whether or not the
 		// existing volume satisfies the request. If so, return a
 		// successful response. If not, return ErrVolumeAlreadyExists.
@@ -428,7 +435,21 @@ func (s *Server) CreateVolume(
 		}
 		return response, nil
 	}
-	log.Printf("Volume with id=%v does not already exist", volumeId)
+	// Generate a random volume name and ensure that it doesn't already exist.
+	var volumeID string
+	for i := 0; i < 10 && volumeID == ""; i++ {
+		tryID := strconv.FormatUint(rand.Uint64(), 36)
+		log.Printf("Attempting to allocate id=%v for requested volume %q", tryID, request.GetName())
+		if _, err := s.volumeGroup.LookupLogicalVolume(tryID); err == nil {
+			log.Printf("Volume id %s already exists, trying again..", tryID)
+			continue
+		}
+		volumeID = tryID
+	}
+	if volumeID == "" {
+		return nil, status.Error(codes.Internal, "Failed to allocate volume ID")
+	}
+	log.Printf("Volume with id=%v does not already exist", volumeID)
 	layout, err := takeVolumeLayoutFromParameters(dupParams(request.GetParameters()))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Invalid volume layout: err=%v", err)
@@ -456,13 +477,8 @@ func (s *Server) CreateVolume(
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid parameters: %v", err)
 	}
 
-	// record the original volume name as a tag
-	tags := make([]string, len(s.tags), len(s.tags)+1)
-	copy(tags, s.tags)
-	tags = append(tags, s.volumeNameToTag(request.GetName()))
-
-	log.Printf("Creating logical volume id=%v, size=%v, tags=%v, params=%v", volumeId, size, tags, request.GetParameters())
-	lv, err := s.volumeGroup.CreateLogicalVolume(volumeId, size, tags, lvopts...)
+	log.Printf("Creating logical volume id=%v, size=%v, tags=%v, params=%v", volumeID, size, tags, request.GetParameters())
+	lv, err := s.volumeGroup.CreateLogicalVolume(volumeID, size, tags, lvopts...)
 	if err != nil {
 		if err == lvm.ErrInvalidLVName {
 			return nil, status.Errorf(
@@ -490,7 +506,7 @@ func (s *Server) CreateVolume(
 	response := &csi.CreateVolumeResponse{
 		&csi.Volume{
 			int64(lv.SizeInBytes()),
-			volumeId,
+			volumeID,
 			attr,
 		},
 	}
@@ -709,8 +725,31 @@ func (s *Server) volumeNameToId(volname string) string {
 	return s.volumeGroup.Name() + "_" + volname
 }
 
+const (
+	tagVolumeNameEncodedPrefix = "VN+" // used when volume name is not tag-safe
+	tagVolumeNamePlainPrefix   = "VN." // used when volume name is tag-safe
+)
+
+var tagSafeChars map[rune]struct{} = func() map[rune]struct{} {
+	const safe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_+.-1234567890"
+	m := make(map[rune]struct{})
+	for _, r := range safe {
+		m[r] = struct{}{}
+	}
+	return m
+}()
+
+// volumeNameToTag attempts to preserve the suggested volume name as a suffix of the
+// returned string, unless it contains unsafe chars in which case it is encoded.
 func (s *Server) volumeNameToTag(volname string) string {
-	return "VN+" + base64.RawURLEncoding.EncodeToString([]byte(volname))
+	for _, r := range volname {
+		if _, ok := tagSafeChars[r]; ok {
+			continue
+		}
+		return tagVolumeNameEncodedPrefix +
+			base64.RawURLEncoding.EncodeToString([]byte(volname))
+	}
+	return tagVolumeNamePlainPrefix + volname
 }
 
 func (s *Server) ListVolumes(


### PR DESCRIPTION
* CO-generated volume names are stored in a LV tag, useful for implementing idempotent create operations and also for operators seeking to reconcile CO logs w/ realized volume state.
* Plugin-generated volume names are chosen at random, and are short. This results in a more reasonably sized, fully-qualified VG/LV identifier, as well as more reasonable physical device names for each LV. 

https://jira.mesosphere.com/browse/DCOS_OSS-5126