### PR TITLE
csilvm: fix stopping of uptime reporting on shutdown

### DIFF
--- a/cmd/csilvm/csilvm.go
+++ b/cmd/csilvm/csilvm.go
@@ -183,7 +183,7 @@ func main() {
 	if err := s.Setup(); err != nil {
 		log.Fatalf("[%s] error initializing csilvm plugin: err=%v", *vgnameF, err)
 	}
-	defer s.ReportUptime()
+	defer s.ReportUptime()()
 	csi.RegisterIdentityServer(grpcServer, csilvm.IdentityServerValidator(s))
 	csi.RegisterControllerServer(grpcServer, csilvm.ControllerServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))
 	csi.RegisterNodeServer(grpcServer, csilvm.NodeServerValidator(s, s.RemovingVolumeGroup(), s.SupportedFilesystems()))

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -2997,6 +2997,6 @@ func startTest(vgname string, pvnames []string, serverOpts ...ServerOpt) (client
 	if err := server.Setup(); err != nil {
 		panic(err)
 	}
-	clean.Add(func() error { server.ReportUptime(); return nil })
+	clean.Add(func() error { server.ReportUptime()(); return nil })
 	return client, clean.Unwind
 }


### PR DESCRIPTION
The uptime reporting goroutine would never exit, as I
deferred the constructor not the CloseFunc.