### PR TITLE
pkg/csilvm: don't treat unexpected PVs as an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ The following metrics are reported:
 - csilvm_bytes_total: the total number of bytes in the volume group
 - csilvm_bytes_free: the number of bytes available for creating a linear logical volume
 - csilvm_bytes_used: the number of bytes allocated to active logical volumes
+- csilvm_pvs: the number of physical volumes in the volume group
+- csilvm_missing_pvs: the number of pvs given on the command-line but are not found in the volume group
+- csilvm_unexpected_pvs: the number of pvs not given on the command-line but are found in the volume group
+- csilvm_lookup_pv_errs: the number of errors encountered while looking for pvs specified on the command-line
 
 Furthermore, all metrics are tagged with `volume-group` set to the
 `-volume-group` command-line option.


### PR DESCRIPTION
There are valid reasons for the list of PVs that comprise a VG to change. 

For example, 
- one out of several PVs might be broken
- the administrator manually extends or shrinks a volume group by adding/removing PVs

This PR changes the Probe and Setup behaviour to log errors when the list of PVs do not match the list provided on the command line, or when a PV's metadata is corrupted, but does not return the errors.

This is a consequence of the CSI not allowing us to report Healthy vs. Degraded vs. Broken.

Fixes https://jira.mesosphere.com/browse/DCOS_OSS-5264