### PR TITLE
pkg/csilvm: respect limit_bytes in CreateVolume

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ Once all the PVs exist, the new volume group is created consisting of those PVs 
 The plugin is completely stateless and performs no locking around operations.
 Instead, it relies on LVM2 to lock around operations that are not reentrant.
 
-
 #### Logical volume naming
 
 The volume group name is specified at startup through the `-volume-group` argument.
@@ -290,13 +289,23 @@ Examples:
 * If the CO-specified volume name is `test-volume`, then the generated LV tag is `VN.test-volume`.
 * If the CO-specified volume name is `hello volume`, then the generated LV tag is `VN+aGVsbG8gdm9sdW1l`.
 
+#### Logical volume sizes
+
+The `CreateVolume` RPC will attempt to allocate a volume size that both:
+
+* satisfies the requested capacity with the range limits given, and;
+* aligns with an LVM extent boundary (LVM default is 4MiB)
+
+The plugin will choose the smallest size within the requested capacity range that aligns to an extent boundary.
+If the plugin cannot align on an extent boundary within the requested capacity range, then the `CreateVolume` RPC will return an error.
+For example, if the requested capacity is *exactly* 25MiB (RequiredBytes = LimitBytes = 25MiB) then the RPC will fail because 25MiB does not align to the default 4MiB extent boundary.
+
 #### SINGLE_NODE_READER_ONLY
 
 It is not possible to bind mount a device as 'ro' and thereby prevent write access to it.
 
 As such, this plugin does not support the `SINGLE_NODE_READER_ONLY` access mode for a
 volume of access type `BLOCK_DEVICE`.
-
 
 # Issues
 

--- a/pkg/csilvm/csilvm_test.go
+++ b/pkg/csilvm/csilvm_test.go
@@ -1072,7 +1072,7 @@ func TestListVolumes_TwoVolumes(t *testing.T) {
 	// Add the first volume.
 	req := testCreateVolumeRequest()
 	req.Name = "test-volume-1"
-	req.CapacityRange.RequiredBytes /= 2
+	req.CapacityRange.RequiredBytes /= 3
 	resp, err := client.CreateVolume(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -1098,7 +1098,9 @@ func TestListVolumes_TwoVolumes(t *testing.T) {
 		t.Fatalf("ListVolumes returned %v entries, expected %d.", len(entries), len(infos))
 	}
 	nameTags := []string{"VN.test-volume-1", "VN.test-volume-2"}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].GetVolume().GetId() < entries[j].GetVolume().GetId() })
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].GetVolume().GetCapacityBytes() < entries[j].GetVolume().GetCapacityBytes()
+	})
 	for i, entry := range entries {
 		had := false
 		for _, info := range infos {

--- a/pkg/csilvm/metrics_test.go
+++ b/pkg/csilvm/metrics_test.go
@@ -1,3 +1,5 @@
+// +build !unit
+
 package csilvm
 
 import (
@@ -69,9 +71,10 @@ func TestMetricsInterceptor(t *testing.T) {
 
 		// A single request that fails
 		createVolumeReq := testCreateVolumeRequest()
-		// Check that trying to create a volume with the same name but
-		// incompatible capacity_range fails.
-		createVolumeReq.CapacityRange.RequiredBytes += 1
+		// Check that trying to create a volume with an invalid
+		// capacity_range fails.
+		createVolumeReq.CapacityRange.RequiredBytes = 0
+		createVolumeReq.CapacityRange.LimitBytes = 0
 		_, err = client.CreateVolume(context.Background(), createVolumeReq)
 		if err == nil {
 			t.Fatalf("Expected error but got nil")

--- a/pkg/csilvm/server.go
+++ b/pkg/csilvm/server.go
@@ -544,7 +544,7 @@ func (s *Server) CreateVolume(
 		if size%extentSize != 0 {
 			sizeBefore := size
 			size = ((size + extentSize) / extentSize) * extentSize
-			log.Printf("Rounding size up from required_bytes (%dMiB) to nearest extent size (%dMiB) to get (%dMiB)", sizeBefore>>20, extentSize>>20, size>>20)
+			log.Printf("Rounding size up from required_bytes (about %dMiB) to nearest extent size (%dMiB) to get (%dMiB)", sizeBefore>>20, extentSize>>20, size>>20)
 		}
 		// Get bytesFree, it is a multiple of extentSize.
 		bytesFree, err := s.volumeGroup.BytesFree(layout)


### PR DESCRIPTION
The CreateVolume call currently does not respect the `CreateVolumeRequest.CapacityRange.limit_bytes` value. It was assumed that if there are more bytes available than request by `.CapacityRange.required_bytes` then the request would succeed.

However, LVM requires that LVs be multiples of the underlying volume group's extent size, typically a multiple if 4MiB. 

This means that if the interval `[required_bytes, limit_bytes]` does not include a multiple of the extent size, then the request cannot actually be served since the resulting volume's size would not fall in that range (it would be `required_bytes` rounded upwards to the nearest extent size.)

This PR fixes CreateVolume to return an error instead.